### PR TITLE
Avoid variable shadowing warnings

### DIFF
--- a/accountvalue.cpp
+++ b/accountvalue.cpp
@@ -889,14 +889,14 @@ void AccountValue::TxTakeWD()
     //   max loan: cannot become overloaned until end of policy year.
     // However, lmi provides a variety of implementations instead of
     // only one.
-    double MaxWD =
+    double maxWD =
           AVUnloaned
         + (AVRegLn  + AVPrfLn)
         - (RegLnBal + PrfLnBal)
         - mlydedtonextmodalpmtdate;
-    if(MaxWD < wd)
+    if(maxWD < wd)
         {
-        wd = MaxWD;
+        wd = maxWD;
         }
 
     AVUnloaned -= wd;

--- a/main_wx_test.cpp
+++ b/main_wx_test.cpp
@@ -210,8 +210,8 @@ class application_test
     struct test_descriptor
     {
         // The pointer must be non-NULL but we don't take ownership of it.
-        test_descriptor(wx_base_test_case* test)
-            :test(test)
+        test_descriptor(wx_base_test_case* t)
+            :test(t)
             ,run(run_default)
         {
         }

--- a/rate_table.cpp
+++ b/rate_table.cpp
@@ -2725,7 +2725,7 @@ void database_impl::delete_table(table::Number number)
     remove_index_entry(number);
 }
 
-void database_impl::save(fs::path const& path)
+void database_impl::save(fs::path const& output_path)
 {
     // This class ensures that we either overwrite both the output .ndx and
     // .dat files or don't change either of them if an error happens (unless a
@@ -2943,7 +2943,7 @@ void database_impl::save(fs::path const& path)
         safe_output_file database_;
     };
 
-    safe_database_output output(path);
+    safe_database_output output(output_path);
 
     save(output.index(), output.database());
 

--- a/solve.cpp
+++ b/solve.cpp
@@ -186,41 +186,41 @@ inline static double SolveWD(double CandidateValue)
 //============================================================================
 void AccountValue::SolveSetPmts
     (double a_Pmt
-    ,int    ThatSolveBegYear
-    ,int    ThatSolveEndYear
+    ,int    thatSolveBegYear
+    ,int    thatSolveEndYear
     )
 {
-    Outlay_->set_ee_modal_premiums(a_Pmt, ThatSolveBegYear, ThatSolveEndYear);
+    Outlay_->set_ee_modal_premiums(a_Pmt, thatSolveBegYear, thatSolveEndYear);
 }
 
 //============================================================================
 void AccountValue::SolveSetSpecAmt
     (double a_Bft
-    ,int    ThatSolveBegYear
-    ,int    ThatSolveEndYear
+    ,int    thatSolveBegYear
+    ,int    thatSolveEndYear
     )
 {
-    DeathBfts_->set_specamt(a_Bft, ThatSolveBegYear, ThatSolveEndYear);
+    DeathBfts_->set_specamt(a_Bft, thatSolveBegYear, thatSolveEndYear);
 }
 
 //============================================================================
 void AccountValue::SolveSetLoans
     (double a_Loan
-    ,int    ThatSolveBegYear
-    ,int    ThatSolveEndYear
+    ,int    thatSolveBegYear
+    ,int    thatSolveEndYear
     )
 {
-    Outlay_->set_new_cash_loans(a_Loan, ThatSolveBegYear, ThatSolveEndYear);
+    Outlay_->set_new_cash_loans(a_Loan, thatSolveBegYear, thatSolveEndYear);
 }
 
 //============================================================================
 void AccountValue::SolveSetWDs
     (double a_WD
-    ,int    ThatSolveBegYear
-    ,int    ThatSolveEndYear
+    ,int    thatSolveBegYear
+    ,int    thatSolveEndYear
     )
 {
-    Outlay_->set_withdrawals(a_WD, ThatSolveBegYear, ThatSolveEndYear);
+    Outlay_->set_withdrawals(a_WD, thatSolveBegYear, thatSolveEndYear);
 }
 
 //============================================================================

--- a/test_coding_rules.cpp
+++ b/test_coding_rules.cpp
@@ -491,9 +491,9 @@ void check_copyright(file const& f)
 
     if(f.is_of_phylum(e_html) && !f.phyloanalyze("^COPYING"))
         {
-        std::ostringstream oss;
-        oss << "Copyright &copy;[^\\n]*" << year;
-        require(f, oss.str(), "lacks current secondary copyright.");
+        std::ostringstream oss2;
+        oss2 << "Copyright &copy;[^\\n]*" << year;
+        require(f, oss2.str(), "lacks current secondary copyright.");
         }
 }
 

--- a/wx_table_generator.cpp
+++ b/wx_table_generator.cpp
@@ -47,11 +47,11 @@ void increase_to_if_smaller(T& first, T second)
 } // Unnamed namespace.
 
 wx_table_generator::wx_table_generator
-    (wxDC& dc_
+    (wxDC& dc
     ,int left_margin
     ,int total_width
     )
-    :dc_(dc_)
+    :dc_(dc)
     ,left_margin_(left_margin)
     ,total_width_(total_width)
     ,char_height_(dc_.GetCharHeight())

--- a/wx_test_about_version.cpp
+++ b/wx_test_about_version.cpp
@@ -202,10 +202,10 @@ LMI_WX_TEST_CASE(about_dialog_version)
             // And then press the default button in it which opens the license.
             struct expect_license_dialog : public wxExpectModalBase<wxDialog>
             {
-                virtual int OnInvoked(wxDialog* d) const
+                virtual int OnInvoked(wxDialog* license_dialog) const
                     {
                     wxHtmlWindow* const
-                        license_win = find_html_window(d, "license");
+                        license_win = find_html_window(license_dialog, "license");
 
                     // This is a rather indirect -- because testing this
                     // directly is not easily possible -- test of the scrollbar

--- a/wx_test_default_update.cpp
+++ b/wx_test_default_update.cpp
@@ -125,7 +125,7 @@ LMI_WX_TEST_CASE(default_update)
         // depending on the skin used.
         static void ToggleUseDOB(wxWindow* usedob_window)
             {
-            wxUIActionSimulator ui;
+            wxUIActionSimulator ui2;
 
             if(dynamic_cast<wxRadioBox*>(usedob_window))
                 {
@@ -134,12 +134,12 @@ LMI_WX_TEST_CASE(default_update)
                 // GTK we also have to explicitly check it by pressing
                 // Space or Enter and as it doesn't do anything under MSW, we
                 // just do it unconditionally to avoid conditional compilation.
-                ui.Char(WXK_DOWN);
-                ui.Char(WXK_SPACE);
+                ui2.Char(WXK_DOWN);
+                ui2.Char(WXK_SPACE);
                 }
             else if(dynamic_cast<wxCheckBox*>(usedob_window))
                 {
-                ui.Char(WXK_SPACE);
+                ui2.Char(WXK_SPACE);
                 }
             else
                 {

--- a/wx_test_paste_census.cpp
+++ b/wx_test_paste_census.cpp
@@ -297,12 +297,12 @@ LMI_WX_TEST_CASE(paste_census)
                 gender_radiobox = dynamic_cast<wxRadioBox*>(gender_window);
             LMI_ASSERT(gender_radiobox);
 
-            wxUIActionSimulator ui;
+            wxUIActionSimulator ui2;
             // Select the last, "Unisex", radio button, by simulating
             // down-arrow twice: female --> male, then male --> unisex.
-            ui.Char(WXK_DOWN);
+            ui2.Char(WXK_DOWN);
             wxYield();
-            ui.Char(WXK_DOWN);
+            ui2.Char(WXK_DOWN);
             wxYield();
 
             LMI_ASSERT_EQUAL(gender_radiobox->GetSelection(), 2);
@@ -370,8 +370,8 @@ LMI_WX_TEST_CASE(paste_census)
                 class_radiobox = dynamic_cast<wxRadioBox*>(class_window);
             LMI_ASSERT(class_radiobox);
 
-            wxUIActionSimulator ui;
-            ui.Char(WXK_UP); // Select the first, "Preferred", radio button.
+            wxUIActionSimulator ui2;
+            ui2.Char(WXK_UP); // Select the first, "Preferred", radio button.
             wxYield();
 
             LMI_ASSERT_EQUAL(class_radiobox->GetSelection(), 0);

--- a/wx_test_validate_output.cpp
+++ b/wx_test_validate_output.cpp
@@ -127,9 +127,9 @@ void init_test_census
     struct change_corp_in_case_defaults_dialog
         :public enter_comments_in_case_defaults_dialog
     {
-        change_corp_in_case_defaults_dialog(std::string const& corp_name)
+        change_corp_in_case_defaults_dialog(std::string const& name)
             :enter_comments_in_case_defaults_dialog("idiosyncrasyZ")
-            ,corp_name_(corp_name)
+            ,corp_name_(name)
             {
             }
 
@@ -139,8 +139,8 @@ void init_test_census
 
             wx_test_focus_controller_child(*dialog, "CorporationName");
 
-            wxUIActionSimulator ui;
-            ui.Text((corp_name_ + " Inc.").c_str());
+            wxUIActionSimulator ui2;
+            ui2.Text((corp_name_ + " Inc.").c_str());
             wxYield();
 
             return wxID_OK;
@@ -161,8 +161,8 @@ void init_test_census
     struct change_name_in_cell_dialog
         :public wxExpectModalBase<MvcController>
     {
-        change_name_in_cell_dialog(std::string const& insured_name)
-            :insured_name(insured_name)
+        change_name_in_cell_dialog(std::string const& name)
+            :insured_name(name)
             {
             }
 
@@ -173,8 +173,8 @@ void init_test_census
 
             wx_test_focus_controller_child(*dialog, "InsuredName");
 
-            wxUIActionSimulator ui;
-            ui.Text(insured_name.c_str());
+            wxUIActionSimulator ui2;
+            ui2.Text(insured_name.c_str());
             wxYield();
 
             return wxID_OK;


### PR DESCRIPTION
This allows lmi code to compile with -Wshadow using both gcc and clang.

See [this post](http://lists.nongnu.org/archive/html/lmi/2016-06/msg00019.html).
