### PR TITLE
Better fix for USE_SO_ATTRIBUTES=1 build

### DIFF
--- a/ce_skin_name.hpp
+++ b/ce_skin_name.hpp
@@ -42,7 +42,7 @@
 /// to end users, but skin names are more esoteric and it is less
 /// confusing to show them as file names rather than apparent phrases.
 
-class ce_skin_name final
+class LMI_SO ce_skin_name final
     :public mc_enum_base
 {
   public:

--- a/datum_string.hpp
+++ b/datum_string.hpp
@@ -30,7 +30,9 @@
 
 #include <string>
 
-class datum_string_base
+// Implicitly-declared special member functions do the right thing.
+
+class LMI_SO datum_string_base
     :public datum_base
 {
   public:

--- a/mc_enum.hpp
+++ b/mc_enum.hpp
@@ -89,7 +89,7 @@ class LMI_SO mc_enum_base
 /// explained in the documentation for class mc_enum_data.
 
 template<typename T>
-class mc_enum final
+class LMI_SO mc_enum final
     :public mc_enum_base
 {
     static_assert(std::is_enum_v<T>);

--- a/preferences_model.cpp
+++ b/preferences_model.cpp
@@ -89,8 +89,6 @@ PreferencesModel::PreferencesModel()
     Load();
 }
 
-PreferencesModel::~PreferencesModel() = default;
-
 void PreferencesModel::AscribeMembers()
 {
     ascribe("CalculationSummaryColumn00"    , &PreferencesModel::CalculationSummaryColumn00    );

--- a/preferences_model.hpp
+++ b/preferences_model.hpp
@@ -43,7 +43,7 @@ class LMI_SO PreferencesModel final
 {
   public:
     PreferencesModel();
-    ~PreferencesModel() override;
+    ~PreferencesModel() override = default;
 
     bool IsModified() const;
     void Load();

--- a/tn_range.hpp
+++ b/tn_range.hpp
@@ -226,7 +226,7 @@ class LMI_SO tn_range_base
 /// the right thing.
 
 template<typename Number, typename Trammel>
-class tn_range final
+class LMI_SO tn_range final
     :public tn_range_base
 {
     static_assert(std::is_base_of_v<trammel_base<Number>,Trammel>);


### PR DESCRIPTION
This adds the missing `LMI_SO` and reverts the workaround used to fix this build previously, which shouldn't be needed.