### PR TITLE
New lmi path

### DIFF
--- a/actuarial_table.cpp
+++ b/actuarial_table.cpp
@@ -203,7 +203,7 @@ void actuarial_table::find_table()
     LMI_ASSERT(0 != table_number_);
 
     fs::path index_path(filename_);
-    index_path = fs::change_extension(index_path, ".ndx");
+    index_path.replace_extension(".ndx");
     fs::ifstream index_ifs(index_path, ios_in_binary());
     if(!index_ifs)
         {
@@ -293,7 +293,7 @@ void actuarial_table::parse_table()
     LMI_ASSERT(-1 == max_select_age_);
 
     fs::path data_path(filename_);
-    data_path = fs::change_extension(data_path, ".dat");
+    data_path.replace_extension(".dat");
     fs::ifstream data_ifs(data_path, ios_in_binary());
     if(!data_ifs)
         {

--- a/actuarial_table.cpp
+++ b/actuarial_table.cpp
@@ -29,12 +29,9 @@
 #include "deserialize_cast.hpp"
 #include "miscellany.hpp"
 #include "oecumenic_enumerations.hpp"   // methuselah
+#include "path.hpp"
 #include "path_utility.hpp"             // fs::path inserter
 #include "ssize_lmi.hpp"
-
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <algorithm>                    // max(), min()
 #include <cctype>                       // toupper()

--- a/authenticity.cpp
+++ b/authenticity.cpp
@@ -30,11 +30,9 @@
 #include "handle_exceptions.hpp"
 #include "md5.hpp"
 #include "md5sum.hpp"
+#include "path.hpp"
 #include "path_utility.hpp"             // fs::path inserter
 #include "timer.hpp"
-
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/operations.hpp>
 
 #include <cstdio>                       // fclose(), fopen()
 #include <cstdlib>                      // exit(), EXIT_FAILURE

--- a/authenticity.cpp
+++ b/authenticity.cpp
@@ -96,7 +96,10 @@ std::string Authenticity::Assay
     // Read saved passkey from file.
     std::string passkey;
     {
-    fs::path passkey_path(data_path / "passkey");
+    fs::path passkey_path("passkey");
+    // Add only non-empty data path to avoid adding "./".
+    if(!data_path.empty())
+        passkey_path = data_path / passkey_path;
     fs::ifstream is(passkey_path);
     if(!is)
         {
@@ -138,7 +141,10 @@ std::string Authenticity::Assay
     calendar_date begin(last_yyyy_date ());
     calendar_date end  (gregorian_epoch());
     {
-    fs::path expiry_path(data_path / "expiry");
+    fs::path expiry_path("expiry");
+    // Add only non-empty data path to avoid adding "./".
+    if(!data_path.empty())
+        expiry_path = data_path / expiry_path;
     fs::ifstream is(expiry_path);
     if(!is)
         {

--- a/authenticity.hpp
+++ b/authenticity.hpp
@@ -25,9 +25,8 @@
 #include "config.hpp"
 
 #include "calendar_date.hpp"
+#include "path.hpp"
 #include "so_attributes.hpp"
-
-#include <boost/filesystem/path.hpp>
 
 #include <string>
 

--- a/authenticity_test.cpp
+++ b/authenticity_test.cpp
@@ -28,12 +28,9 @@
 #include "md5.hpp"
 #include "md5sum.hpp"
 #include "miscellany.hpp"
+#include "path.hpp"
 #include "system_command.hpp"
 #include "test_tools.hpp"
-
-#include <boost/filesystem/convenience.hpp> // basename()
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <cstdio>                       // remove()
 #include <cstring>                      // memcpy(), strlen()

--- a/authenticity_test.cpp
+++ b/authenticity_test.cpp
@@ -304,7 +304,7 @@ void PasskeyTest::TestFromAfar() const
 #if defined LMI_MSW
     CheckNominal(__FILE__, __LINE__);
 
-    fs::path const remote_dir_1(fs::absolute(fs::path("F:/", fs::native)));
+    fs::path const remote_dir_1(fs::absolute("F:/"));
     if(!fs::exists(remote_dir_1))
         {
         goto done;

--- a/authenticity_test.cpp
+++ b/authenticity_test.cpp
@@ -288,7 +288,7 @@ void PasskeyTest::TestFromAfar() const
 {
     CheckNominal(__FILE__, __LINE__);
 
-    std::string const tmp = "/tmp/" + fs::basename(__FILE__);
+    fs::path const tmp = "/tmp" / fs::path{__FILE__}.stem();
     fs::path const remote_dir_0(fs::absolute(tmp));
     fs::create_directory(remote_dir_0);
     BOOST_TEST(fs::exists(remote_dir_0) && fs::is_directory(remote_dir_0));

--- a/authenticity_test.cpp
+++ b/authenticity_test.cpp
@@ -289,7 +289,7 @@ void PasskeyTest::TestFromAfar() const
     CheckNominal(__FILE__, __LINE__);
 
     std::string const tmp = "/tmp/" + fs::basename(__FILE__);
-    fs::path const remote_dir_0(fs::complete(tmp));
+    fs::path const remote_dir_0(fs::absolute(tmp));
     fs::create_directory(remote_dir_0);
     BOOST_TEST(fs::exists(remote_dir_0) && fs::is_directory(remote_dir_0));
     BOOST_TEST_EQUAL(0, chdir(remote_dir_0.string().c_str()));
@@ -304,7 +304,7 @@ void PasskeyTest::TestFromAfar() const
 #if defined LMI_MSW
     CheckNominal(__FILE__, __LINE__);
 
-    fs::path const remote_dir_1(fs::complete(fs::path("F:/", fs::native)));
+    fs::path const remote_dir_1(fs::absolute(fs::path("F:/", fs::native)));
     if(!fs::exists(remote_dir_1))
         {
         goto done;

--- a/authenticity_test.cpp
+++ b/authenticity_test.cpp
@@ -276,13 +276,6 @@ void PasskeyTest::CheckNominal(char const* file, int line) const
 /// tested because it's common and problematic. This test assumes that
 /// an 'F:' drive exists and is not the "current" drive; it is skipped
 /// if no 'F:' drive exists.
-///
-/// BOOST !! This test traps an exception that boost-1.33.1 can throw
-/// if exists("F:/") returns true but ::GetFileAttributesA() fails.
-/// That's supposed to be impossible because the is_directory()
-/// documentation says:
-///   "Throws: if !exists(ph)"
-/// but it can be reproduced by placing an unformatted disk in "F:".
 
 void PasskeyTest::TestFromAfar() const
 {

--- a/authenticity_test.cpp
+++ b/authenticity_test.cpp
@@ -310,20 +310,7 @@ void PasskeyTest::TestFromAfar() const
         goto done;
         }
 
-    try
-        {
-        BOOST_TEST(fs::is_directory(remote_dir_1));
-        }
-    catch(std::exception const& e)
-        {
-        std::string s(e.what());
-        if(contains(s, "boost::filesystem::is_directory"))
-            {
-            BOOST_TEST(false);
-            goto done;
-            }
-        throw;
-        }
+    BOOST_TEST(fs::is_directory(remote_dir_1));
 
     BOOST_TEST_EQUAL(0, chdir(remote_dir_1.string().c_str()));
     BOOST_TEST_EQUAL(remote_dir_1.string(), fs::current_path().string());

--- a/cache_file_reads.hpp
+++ b/cache_file_reads.hpp
@@ -25,8 +25,7 @@
 #include "config.hpp"
 
 #include "assert_lmi.hpp"
-
-#include <boost/filesystem/operations.hpp>
+#include "path.hpp"
 
 #include <ctime>                        // time_t
 #include <map>

--- a/cache_file_reads.hpp
+++ b/cache_file_reads.hpp
@@ -69,7 +69,7 @@ class file_cache
     retrieved_type retrieve_or_reload(std::string const& filename)
         {
         // Throws if !exists(filename).
-        std::time_t const write_time = fs::last_write_time(filename);
+        auto const write_time = fs::last_write_time(filename);
 
         auto i = cache_.lower_bound(filename);
         if
@@ -100,8 +100,8 @@ class file_cache
 
     struct record
     {
-        retrieved_type data;
-        std::time_t    write_time;
+        retrieved_type     data;
+        fs::file_time_type write_time;
     };
 
     std::map<std::string,record> cache_;

--- a/cache_file_reads_test.cpp
+++ b/cache_file_reads_test.cpp
@@ -83,7 +83,7 @@ void cache_file_reads_test::test_preconditions()
     // The file must exist.
     BOOST_TEST_THROW
         (X::read_via_cache("no_such_file")
-        ,boost::filesystem::filesystem_error
+        ,std::filesystem::filesystem_error
         ,lmi_test::what_regex("no_such_file")
         );
 }

--- a/cache_file_reads_test.cpp
+++ b/cache_file_reads_test.cpp
@@ -25,10 +25,9 @@
 
 #include "istream_to_string.hpp"
 #include "miscellany.hpp"               // ios_in_binary()
+#include "path.hpp"
 #include "test_tools.hpp"
 #include "timer.hpp"
-
-#include <boost/filesystem/exception.hpp>
 
 #include <fstream>
 

--- a/ce_product_name.cpp
+++ b/ce_product_name.cpp
@@ -28,12 +28,9 @@
 #include "contains.hpp"
 #include "facets.hpp"
 #include "global_settings.hpp"
+#include "path.hpp"
 #include "path_utility.hpp"             // fs::path inserter
 #include "ssize_lmi.hpp"
-
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <algorithm>                    // find()
 #include <istream>

--- a/ce_product_name.cpp
+++ b/ce_product_name.cpp
@@ -42,15 +42,18 @@ std::vector<std::string> fetch_product_names()
 {
     fs::path path(global_settings::instance().data_directory());
     std::vector<std::string> names;
-    fs::directory_iterator i(path);
-    fs::directory_iterator end_i;
-    for(; i != end_i; ++i)
+    for(auto const& i : fs::directory_iterator(path))
         {
-        if(".policy" != fs::extension(*i) || is_directory(*i))
+        if(i.is_directory())
             {
             continue;
             }
-        names.push_back(basename(*i));
+        auto const current_path{i.path()};
+        if(".policy" != current_path.extension())
+            {
+            continue;
+            }
+        names.push_back(basename(current_path));
         }
 
     if(names.empty())

--- a/ce_product_name.cpp
+++ b/ce_product_name.cpp
@@ -53,7 +53,7 @@ std::vector<std::string> fetch_product_names()
             {
             continue;
             }
-        names.push_back(basename(current_path));
+        names.push_back(current_path.stem().string());
         }
 
     if(names.empty())

--- a/ce_skin_name.cpp
+++ b/ce_skin_name.cpp
@@ -41,15 +41,18 @@ std::vector<std::string> fetch_skin_names()
 {
     fs::path path(global_settings::instance().data_directory());
     std::vector<std::string> names;
-    fs::directory_iterator i(path);
-    fs::directory_iterator end_i;
-    for(; i != end_i; ++i)
+    for(auto const& i : fs::directory_iterator(path))
         {
-        if(is_directory(*i) || ".xrc" != fs::extension(*i))
+        if(i.is_directory())
             {
             continue;
             }
-        std::string const name(i->leaf());
+        auto const current_path{i.path()};
+        if(".xrc" != current_path.extension())
+            {
+            continue;
+            }
+        std::string const name(current_path.leaf());
         if(!begins_with(name, "skin"))
             {
             continue;

--- a/ce_skin_name.cpp
+++ b/ce_skin_name.cpp
@@ -29,12 +29,9 @@
 #include "facets.hpp"
 #include "global_settings.hpp"
 #include "miscellany.hpp"               // begins_with()
+#include "path.hpp"
 #include "path_utility.hpp"             // fs::path inserter
 #include "ssize_lmi.hpp"
-
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <algorithm>                    // find()
 

--- a/ce_skin_name.cpp
+++ b/ce_skin_name.cpp
@@ -52,7 +52,7 @@ std::vector<std::string> fetch_skin_names()
             {
             continue;
             }
-        std::string const name(current_path.leaf());
+        std::string const name(current_path.filename().string());
         if(!begins_with(name, "skin"))
             {
             continue;

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -41,6 +41,7 @@
 #include "ledger.hpp"
 #include "ledger_text_formats.hpp"
 #include "miscellany.hpp"               // is_ok_for_cctype(), ios_out_app_binary()
+#include "path.hpp"
 #include "path_utility.hpp"             // unique_filepath()
 #include "rtti_lmi.hpp"                 // lmi::TypeInfo
 #include "safely_dereference_as.hpp"
@@ -49,8 +50,6 @@
 #include "value_cast.hpp"
 #include "wx_new.hpp"
 #include "wx_utility.hpp"               // class ClipboardEx
-
-#include <boost/filesystem/convenience.hpp> // basename()
 
 #include <wx/datectrl.h>
 #include <wx/grid.h>

--- a/census_view.cpp
+++ b/census_view.cpp
@@ -1998,7 +1998,7 @@ void CensusView::DoCopyCensus() const
     configurable_settings const& c = configurable_settings::instance();
     std::string const& print_dir = c.print_directory();
     std::string const& tsv_ext = c.spreadsheet_file_extension();
-    std::string const f = fs::basename(base_filename()) + ".census.cns";
+    fs::path const f = fs::path{base_filename()}.replace_extension(".census.cns");
     fs::path const g(modify_directory(f, print_dir));
     std::string file_name = unique_filepath(g, tsv_ext).string();
     std::ofstream ofs(file_name.c_str(), ios_out_app_binary());

--- a/config.hpp
+++ b/config.hpp
@@ -25,12 +25,6 @@
 #ifndef config_hpp
 #define config_hpp
 
-#if defined __cplusplus
-// Namespace alii.
-namespace boost {namespace filesystem {} }
-namespace fs = boost::filesystem;
-#endif // defined __cplusplus
-
 // The msw platform-identifying macro that its vendor encourages
 // people to use contains the word "win". I don't consider a non-free
 // operating system a win, and won't advertise it as such by writing

--- a/configurable_settings.cpp
+++ b/configurable_settings.cpp
@@ -31,12 +31,9 @@
 #include "map_lookup.hpp"
 #include "mc_enum.hpp"                  // all_strings<>()
 #include "mc_enum_type_enums.hpp"       // mcenum_report_column
+#include "path.hpp"
 #include "path_utility.hpp"             // validate_directory(), validate_filepath()
 #include "platform_dependent.hpp"       // access()
-
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <iterator>                     // istream_iterator
 #include <sstream>

--- a/configurable_settings.cpp
+++ b/configurable_settings.cpp
@@ -31,9 +31,12 @@
 #include "map_lookup.hpp"
 #include "mc_enum.hpp"                  // all_strings<>()
 #include "mc_enum_type_enums.hpp"       // mcenum_report_column
-#include "path.hpp"
 #include "path_utility.hpp"             // validate_directory(), validate_filepath()
 #include "platform_dependent.hpp"       // access()
+
+#include <boost/filesystem/fstream.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
 
 #include <iterator>                     // istream_iterator
 #include <sstream>
@@ -119,7 +122,7 @@ std::string const& configuration_filepath()
         }
 
     validate_filepath(filename, "Configurable-settings file");
-    complete_path = fs::system_complete(filename).string();
+    complete_path = fs::absolute(filename).string();
     return complete_path;
 }
 
@@ -145,7 +148,7 @@ configurable_settings::configurable_settings()
 
     try
         {
-        default_input_filename_ = fs::system_complete(default_input_filename_).string();
+        default_input_filename_ = fs::absolute(default_input_filename_).string();
 // Performing this test seems like a good idea, but it would flag
 // an empty path as an error.
 //      validate_filepath(default_input_filename_, "Default input file");
@@ -161,13 +164,13 @@ configurable_settings::configurable_settings()
 
     try
         {
-        print_directory_ = fs::system_complete(print_directory_).string();
+        print_directory_ = fs::absolute(print_directory_).string();
         validate_directory(print_directory_, "Print directory");
         }
     catch(...)
         {
         report_exception();
-        print_directory_ = fs::system_complete(AddDataDir(".")).string();
+        print_directory_ = fs::absolute(AddDataDir(".")).string();
         warning()
             << "If possible, data directory '"
             << print_directory_

--- a/configurable_settings.cpp
+++ b/configurable_settings.cpp
@@ -146,25 +146,11 @@ configurable_settings::configurable_settings()
     ascribe_members();
     load();
 
-    try
-        {
-        default_input_filename_ = fs::absolute(default_input_filename_).string();
-// Performing this test seems like a good idea, but it would flag
-// an empty path as an error.
-//      validate_filepath(default_input_filename_, "Default input file");
-        }
-    catch(...)
-        {
-        report_exception();
-        // Silently replace invalid path with an empty string,
-        // which will produce an informative diagnostic when
-        // a default is needed.
-        default_input_filename_ = {};
-        }
+    default_input_filename_ = fs::absolute(default_input_filename_).string();
+    print_directory_        = fs::absolute(print_directory_       ).string();
 
     try
         {
-        print_directory_ = fs::absolute(print_directory_).string();
         validate_directory(print_directory_, "Print directory");
         }
     catch(...)

--- a/configurable_settings_test.cpp
+++ b/configurable_settings_test.cpp
@@ -24,10 +24,8 @@
 #include "configurable_settings.hpp"
 
 #include "miscellany.hpp"               // ios_out_trunc_binary()
+#include "path.hpp"
 #include "test_tools.hpp"
-
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/path.hpp>
 
 class configurable_settings_test
 {

--- a/configurable_settings_test.cpp
+++ b/configurable_settings_test.cpp
@@ -24,7 +24,6 @@
 #include "configurable_settings.hpp"
 
 #include "miscellany.hpp"               // ios_out_trunc_binary()
-#include "path_utility.hpp"             // initialize_filesystem()
 #include "test_tools.hpp"
 
 #include <boost/filesystem/fstream.hpp>
@@ -97,9 +96,6 @@ void configurable_settings_test::test_backward_compatibility()
 
 int test_main(int, char*[])
 {
-    // Absolute paths require "native" name-checking policy for msw.
-    initialize_filesystem();
-
     configurable_settings_test::test();
 
     return EXIT_SUCCESS;

--- a/data_directory.cpp
+++ b/data_directory.cpp
@@ -31,7 +31,7 @@
 std::string AddDataDir(std::string const& a_filename)
 {
     fs::path path(a_filename);
-    LMI_ASSERT(a_filename == path.leaf());
+    LMI_ASSERT(a_filename == path.filename());
 
     path = global_settings::instance().data_directory() / path;
     return path.string();

--- a/data_directory.cpp
+++ b/data_directory.cpp
@@ -25,9 +25,7 @@
 
 #include "assert_lmi.hpp"
 #include "global_settings.hpp"
-
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem/path.hpp>
+#include "path.hpp"
 
 //============================================================================
 std::string AddDataDir(std::string const& a_filename)

--- a/dbdict.cpp
+++ b/dbdict.cpp
@@ -37,14 +37,10 @@
 #include "miscellany.hpp"
 #include "my_proem.hpp"                 // ::write_proem()
 #include "oecumenic_enumerations.hpp"
+#include "path.hpp"
 #include "premium_tax.hpp"              // premium_tax_rates_for_life_insurance()
 #include "xml_lmi.hpp"
 #include "xml_serialize.hpp"
-
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <vector>
 

--- a/dbdict.cpp
+++ b/dbdict.cpp
@@ -1091,7 +1091,8 @@ void print_databases()
             {
             DBDictionary const z(i->string());
 
-            fs::path out_file = fs::change_extension(*i, ".dbt");
+            fs::path out_file = *i;
+            out_file.replace_extension(".dbt");
             fs::ofstream os(out_file, ios_out_trunc_binary());
             for(auto const& j : z.member_names())
                 {

--- a/dbdict.cpp
+++ b/dbdict.cpp
@@ -1079,19 +1079,22 @@ void DBDictionary::InitAntediluvian()
 void print_databases()
 {
     fs::path path(global_settings::instance().data_directory());
-    fs::directory_iterator i(path);
-    fs::directory_iterator end_i;
-    for(; i != end_i; ++i)
+    for(auto const& i : fs::directory_iterator(path))
         {
-        if(is_directory(*i) || ".database" != fs::extension(*i))
+        if(i.is_directory())
+            {
+            continue;
+            }
+        auto const current_path{i.path()};
+        if(".database" != current_path.extension())
             {
             continue;
             }
         try
             {
-            DBDictionary const z(i->string());
+            DBDictionary const z(current_path.string());
 
-            fs::path out_file = *i;
+            fs::path out_file{current_path};
             out_file.replace_extension(".dbt");
             fs::ofstream os(out_file, ios_out_trunc_binary());
             for(auto const& j : z.member_names())

--- a/emit_ledger.cpp
+++ b/emit_ledger.cpp
@@ -33,11 +33,9 @@
 #include "ledger_pdf.hpp"
 #include "ledger_text_formats.hpp"
 #include "miscellany.hpp"               // ios_out_trunc_binary()
+#include "path.hpp"
 #include "path_utility.hpp"             // unique_filepath()
 #include "timer.hpp"
-
-#include <boost/filesystem/convenience.hpp> // change_extension()
-#include <boost/filesystem/fstream.hpp>
 
 #include <iostream>
 #include <string>

--- a/emit_ledger.cpp
+++ b/emit_ledger.cpp
@@ -123,7 +123,7 @@ double ledger_emitter::emit_cell
     if(emission_ & mce_emit_test_data)
         {
         fs::ofstream ofs
-            (fs::change_extension(cell_filepath, ".test")
+            (fs::path{cell_filepath}.replace_extension(".test")
             ,ios_out_trunc_binary()
             );
         ledger.Spew(ofs);
@@ -150,7 +150,7 @@ double ledger_emitter::emit_cell
         fs::path out_file =
             cell_filepath.string() == c.custom_input_0_filename()
             ? c.custom_output_0_filename()
-            : fs::change_extension(cell_filepath, ".test0")
+            : fs::path{cell_filepath}.replace_extension(".test0")
             ;
         custom_io_0_write(ledger, out_file.string());
         }
@@ -160,7 +160,7 @@ double ledger_emitter::emit_cell
         fs::path out_file =
             cell_filepath.string() == c.custom_input_1_filename()
             ? c.custom_output_1_filename()
-            : fs::change_extension(cell_filepath, ".test1")
+            : fs::path{cell_filepath}.replace_extension(".test1")
             ;
         custom_io_1_write(ledger, out_file.string());
         }

--- a/emit_ledger.hpp
+++ b/emit_ledger.hpp
@@ -25,9 +25,8 @@
 #include "config.hpp"
 
 #include "mc_enum_type_enums.hpp"       // enum mcenum_emission
+#include "path.hpp"
 #include "so_attributes.hpp"
-
-#include <boost/filesystem/path.hpp>
 
 #include <memory>                       // unique_ptr
 

--- a/file_command_wx.cpp
+++ b/file_command_wx.cpp
@@ -25,9 +25,7 @@
 
 #include "alert.hpp"
 #include "force_linking.hpp"
-
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem/path.hpp>
+#include "path.hpp"
 
 #include <wx/mimetype.h>
 #include <wx/utils.h>                   // wxExecute()

--- a/file_command_wx.cpp
+++ b/file_command_wx.cpp
@@ -63,7 +63,7 @@ void concrete_file_command
         okay = ft->GetOpenCommand
             (&cmd
             ,wxFileType::MessageParameters
-                (path.native_file_string()
+                (wxString::FromUTF8(path.string())
                 ,""
                 )
             );
@@ -73,7 +73,7 @@ void concrete_file_command
         okay = ft->GetPrintCommand
             (&cmd
             ,wxFileType::MessageParameters
-                (path.native_file_string()
+                (wxString::FromUTF8(path.string())
                 ,""
                 )
             );
@@ -90,7 +90,7 @@ void concrete_file_command
             << "Unable to determine command to '"
             << action
             << "' file '"
-            << path.native_file_string()
+            << path
             << "'."
             << LMI_FLUSH
             ;
@@ -102,7 +102,7 @@ void concrete_file_command
             << "Unable to '"
             << action
             << "' file '"
-            << path.native_file_string()
+            << path
             << "'. Return code: '"
             << okay
             << "'."

--- a/file_command_wx.cpp
+++ b/file_command_wx.cpp
@@ -45,7 +45,7 @@ void concrete_file_command
     )
 {
     fs::path path(file);
-    std::string extension = fs::extension(path);
+    std::string const extension = path.extension().string();
 
     std::unique_ptr<wxFileType> const ft
         (wxTheMimeTypesManager->GetFileTypeFromExtension(extension)

--- a/fund_data.cpp
+++ b/fund_data.cpp
@@ -27,13 +27,11 @@
 #include "assert_lmi.hpp"
 #include "data_directory.hpp"
 #include "my_proem.hpp"                 // ::write_proem()
+#include "path.hpp"
 #include "platform_dependent.hpp"       // access()
 #include "ssize_lmi.hpp"
 #include "xml_lmi.hpp"
 #include "xml_serialize.hpp"
-
-#include <boost/filesystem/convenience.hpp> // basename()
-#include <boost/filesystem/path.hpp>
 
 //============================================================================
 FundInfo::FundInfo

--- a/fund_data.cpp
+++ b/fund_data.cpp
@@ -119,7 +119,7 @@ void FundData::Write(std::string const& a_Filename) const
     xml_lmi::xml_document document(xml_root_name());
     xml::element& root = document.root_node();
 
-    ::write_proem(document, fs::basename(fs::path(a_Filename)));
+    ::write_proem(document, fs::path{a_Filename}.stem().string());
 
     xml_lmi::set_attr(root, "version", "0");
     xml_serialize::to_xml(root, FundInfo_);

--- a/generate_product_files.cpp
+++ b/generate_product_files.cpp
@@ -24,7 +24,6 @@
 #include "dbdict.hpp"
 #include "fund_data.hpp"
 #include "main_common.hpp"
-#include "path_utility.hpp"             // initialize_filesystem()
 #include "product_data.hpp"
 #include "rounding_rules.hpp"
 #include "stratified_charges.hpp"
@@ -34,8 +33,6 @@
 
 int try_main(int, char*[])
 {
-    initialize_filesystem();
-
     std::cout << "Generating product files." << std::endl;
 
     DBDictionary       ::write_database_files ();

--- a/global_settings.cpp
+++ b/global_settings.cpp
@@ -84,7 +84,7 @@ void global_settings::set_regression_testing(bool b)
 void global_settings::set_data_directory(std::string const& s)
 {
     validate_directory(s, "Data directory");
-    data_directory_ = fs::system_complete(s);
+    data_directory_ = fs::absolute(s);
 }
 
 void global_settings::set_prospicience_date(calendar_date const& d)

--- a/global_settings.hpp
+++ b/global_settings.hpp
@@ -99,7 +99,7 @@ class LMI_SO global_settings final
     std::string pyx_                 {};
     bool custom_io_0_                {false};
     bool regression_testing_         {false};
-    fs::path data_directory_         {fs::system_complete(".")};
+    fs::path data_directory_         {fs::absolute(".")};
     calendar_date prospicience_date_ {last_yyyy_date()};
 };
 

--- a/global_settings.hpp
+++ b/global_settings.hpp
@@ -25,10 +25,8 @@
 #include "config.hpp"
 
 #include "calendar_date.hpp"
+#include "path.hpp"
 #include "so_attributes.hpp"
-
-#include <boost/filesystem/operations.hpp> // fs::system_complete()
-#include <boost/filesystem/path.hpp>
 
 #include <string>
 

--- a/global_settings.hpp
+++ b/global_settings.hpp
@@ -55,7 +55,7 @@
 /// products before approval.
 ///
 /// data_directory_: Path to data files, initialized to ".", not an
-/// empty string. Reason: objects of the boost filesystem library's
+/// empty string. Reason: objects of the std::filesystem library's
 /// path class are created from these strings, which, if the strings
 /// were empty, would trigger exceptions when passed to that library's
 /// directory_iterator ctor.

--- a/global_settings_test.cpp
+++ b/global_settings_test.cpp
@@ -22,12 +22,9 @@
 #include "pchfile.hpp"
 
 #include "global_settings.hpp"
+#include "path.hpp"
 
 #include "test_tools.hpp"
-
-#include <boost/filesystem/exception.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 
 void test_directory_exceptions()
 {

--- a/global_settings_test.cpp
+++ b/global_settings_test.cpp
@@ -83,9 +83,9 @@ int test_main(int, char*[])
 
     fs::path path(global_settings::instance().data_directory());
 
-    fs::directory_iterator i(path);
+    fs::directory_iterator const i(path);
 
-    BOOST_TEST(exists(*i));
+    BOOST_TEST(i->exists());
 
     // Certain other operations are required to throw.
 

--- a/global_settings_test.cpp
+++ b/global_settings_test.cpp
@@ -91,16 +91,6 @@ int test_main(int, char*[])
 
     test_directory_exceptions();
 
-    // Attempting to set a default name-checking policy after creating
-    // an instance of class global_settings should throw. Test this in
-    // order to guard against changes to the boost filesystem library.
-
-    BOOST_TEST_THROW
-        (fs::path::default_name_check(fs::native)
-        ,fs::filesystem_error
-        ,""
-        );
-
     // 'ash_nazg' implies 'mellon'.
     global_settings::instance().set_mellon(false);
     BOOST_TEST(!global_settings::instance().mellon());

--- a/global_settings_test.cpp
+++ b/global_settings_test.cpp
@@ -23,7 +23,6 @@
 
 #include "global_settings.hpp"
 
-#include "path_utility.hpp"             // initialize_filesystem()
 #include "test_tools.hpp"
 
 #include <boost/filesystem/exception.hpp>
@@ -78,10 +77,6 @@ void test_directory_exceptions()
 
 int test_main(int, char*[])
 {
-    // Absolute paths require "native" name-checking policy for msw.
-
-    initialize_filesystem();
-
     // Initial values of 'directory' data members must be valid: the
     // operations tested here are required not to throw.
 

--- a/gpt_server.cpp
+++ b/gpt_server.cpp
@@ -508,7 +508,7 @@ gpt_server::gpt_server(mcenum_emission emission) : emission_(emission)
 
 bool gpt_server::operator()(fs::path const& file_path)
 {
-    std::string const extension = fs::extension(file_path);
+    std::string const extension = file_path.extension().string();
     if(".gpt" == extension)
         {
         Timer timer;

--- a/gpt_server.cpp
+++ b/gpt_server.cpp
@@ -538,7 +538,7 @@ bool gpt_server::operator()(fs::path const& file_path, gpt_input const& z)
     timer.restart();
     if(mce_emit_test_data & emission_)
         {
-        state_.save(fs::change_extension(file_path, ".gpt.xml"));
+        state_.save(fs::path{file_path}.replace_extension(".gpt.xml"));
         }
     seconds_for_output_       = timer.stop().elapsed_seconds();
     conditionally_show_timings_on_stdout();

--- a/gpt_server.cpp
+++ b/gpt_server.cpp
@@ -43,6 +43,7 @@
 #include "mc_enum_types_aux.hpp"        // mc_state_from_string()
 #include "miscellany.hpp"               // each_equal(), ios_out_trunc_binary()
 #include "oecumenic_enumerations.hpp"
+#include "path.hpp"
 #include "path_utility.hpp"             // unique_filepath(), fs::path inserter
 #include "premium_tax.hpp"
 #include "product_data.hpp"
@@ -52,9 +53,6 @@
 #include "stratified_charges.hpp"
 #include "timer.hpp"
 #include "value_cast.hpp"
-
-#include <boost/filesystem/convenience.hpp> // extension(), change_extension()
-#include <boost/filesystem/fstream.hpp>
 
 #include <algorithm>                    // min()
 #include <iostream>

--- a/gpt_server.hpp
+++ b/gpt_server.hpp
@@ -26,9 +26,8 @@
 
 #include "gpt_state.hpp"
 #include "mc_enum_type_enums.hpp"       // enum mcenum_emission
+#include "path.hpp"
 #include "so_attributes.hpp"
-
-#include <boost/filesystem/path.hpp>
 
 class gpt_input;
 

--- a/gpt_state.cpp
+++ b/gpt_state.cpp
@@ -27,10 +27,9 @@
 #include "alert.hpp"
 #include "contains.hpp"
 #include "miscellany.hpp"               // htmlize()
+#include "path.hpp"
 #include "value_cast.hpp"
 #include "xml_lmi.hpp"
-
-#include <boost/filesystem/fstream.hpp>
 
 #include <limits>
 #include <sstream>

--- a/group_values.hpp
+++ b/group_values.hpp
@@ -25,9 +25,8 @@
 #include "config.hpp"
 
 #include "mc_enum_type_enums.hpp"       // enum mcenum_emission
+#include "path.hpp"
 #include "so_attributes.hpp"
-
-#include <boost/filesystem/path.hpp>
 
 #include <memory>                       // shared_ptr
 #include <vector>

--- a/icon_monger.cpp
+++ b/icon_monger.cpp
@@ -26,10 +26,8 @@
 #include "alert.hpp"
 #include "contains.hpp"
 #include "data_directory.hpp"           // AddDataDir()
+#include "path.hpp"
 #include "path_utility.hpp"             // fs::path inserter
-
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <wx/image.h>
 

--- a/illustrator.cpp
+++ b/illustrator.cpp
@@ -53,7 +53,7 @@ illustrator::illustrator(mcenum_emission emission)
 
 bool illustrator::operator()(fs::path const& file_path)
 {
-    std::string const extension = fs::extension(file_path);
+    std::string const extension = file_path.extension().string();
     if(".cns" == extension)
         {
         Timer timer;

--- a/illustrator.cpp
+++ b/illustrator.cpp
@@ -34,12 +34,11 @@
 #include "input.hpp"
 #include "ledgervalues.hpp"
 #include "multiple_cell_document.hpp"
+#include "path.hpp"
 #include "path_utility.hpp"             // fs::path inserter
 #include "platform_dependent.hpp"       // access()
 #include "single_cell_document.hpp"
 #include "timer.hpp"
-
-#include <boost/filesystem/convenience.hpp>
 
 #include <iostream>
 #include <string>

--- a/illustrator.hpp
+++ b/illustrator.hpp
@@ -25,9 +25,8 @@
 #include "config.hpp"
 
 #include "mc_enum_type_enums.hpp"       // enum mcenum_emission
+#include "path.hpp"
 #include "so_attributes.hpp"
-
-#include <boost/filesystem/path.hpp>
 
 #include <memory>                       // shared_ptr
 #include <vector>

--- a/input_test.cpp
+++ b/input_test.cpp
@@ -37,7 +37,6 @@
 #include "global_settings.hpp"
 #include "miscellany.hpp"
 #include "oecumenic_enumerations.hpp"
-#include "path_utility.hpp"             // initialize_filesystem()
 #include "test_tools.hpp"
 #include "timer.hpp"
 #include "xml_lmi.hpp"
@@ -566,9 +565,6 @@ void input_test::mete_ill_xsd()
 
 int test_main(int, char*[])
 {
-    // Absolute paths require "native" name-checking policy for msw.
-    initialize_filesystem();
-
     // Location of '*.xsd' files.
     global_settings::instance().set_data_directory("/opt/lmi/data");
 

--- a/ledger_evaluator.cpp
+++ b/ledger_evaluator.cpp
@@ -39,13 +39,11 @@
 #include "mc_enum_aux.hpp"              // mc_e_vector_to_string_vector()
 #include "miscellany.hpp"               // each_equal(), ios_out_trunc_binary()
 #include "oecumenic_enumerations.hpp"
+#include "path.hpp"
 #include "path_utility.hpp"             // fs::path inserter
 #include "ssize_lmi.hpp"
 #include "value_cast.hpp"
 #include "version.hpp"
-
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <algorithm>                    // transform()
 #include <functional>                   // minus

--- a/ledger_evaluator.hpp
+++ b/ledger_evaluator.hpp
@@ -24,9 +24,8 @@
 
 #include "config.hpp"
 
+#include "path.hpp"
 #include "so_attributes.hpp"
-
-#include <boost/filesystem/path.hpp>
 
 #include <string>
 #include <unordered_map>

--- a/ledger_pdf.hpp
+++ b/ledger_pdf.hpp
@@ -23,8 +23,7 @@
 #define ledger_pdf_hpp
 
 #include "config.hpp"
-
-#include <boost/filesystem/path.hpp>
+#include "path.hpp"
 
 #include <string>
 

--- a/ledger_test.cpp
+++ b/ledger_test.cpp
@@ -26,7 +26,6 @@
 #include "ledger_invariant.hpp"
 #include "ledger_variant.hpp"
 
-#include "path_utility.hpp"             // initialize_filesystem()
 #include "test_tools.hpp"
 #include "timer.hpp"
 
@@ -97,9 +96,6 @@ void ledger_test::test_speed()
 
 int test_main(int, char*[])
 {
-    // Absolute paths require "native" name-checking policy for msw.
-    initialize_filesystem();
-
     ledger_test::test();
 
     return EXIT_SUCCESS;

--- a/main_cgi.cpp
+++ b/main_cgi.cpp
@@ -42,7 +42,6 @@
 #include "main_common.hpp"
 #include "mc_enum_type_enums.hpp"       // mcenum_emission
 #include "miscellany.hpp"
-#include "path_utility.hpp"
 #include "platform_dependent.hpp"       // putenv() [GWC]
 #include "ssize_lmi.hpp"
 #include "timer.hpp"
@@ -88,8 +87,6 @@ void ShowCensusOutput(Input const&, std::string const&, bool);
 int try_main(int argc, char* argv[])
 {
   try {
-    initialize_filesystem();
-
     global_settings::instance().set_data_directory("/opt/lmi/data");
 
     gLogFile.rdbuf()->open

--- a/main_cli.cpp
+++ b/main_cli.cpp
@@ -473,7 +473,6 @@ void process_command_line(int argc, char* argv[])
 
 int try_main(int argc, char* argv[])
 {
-    initialize_filesystem();
     process_command_line(argc, argv);
     return EXIT_SUCCESS;
 }

--- a/main_cli.cpp
+++ b/main_cli.cpp
@@ -341,7 +341,7 @@ void process_command_line(int argc, char* argv[])
                 {
                 LMI_ASSERT(nullptr != getopt_long.optarg);
                 std::string const s(getopt_long.optarg);
-                std::string const e = fs::extension(s);
+                std::string const e = fs::path{s}.extension().string();
                 if(".cns" == e || ".ill" == e || ".ini" == e || ".inix" == e)
                     {
                     illustrator_names.push_back(getopt_long.optarg);

--- a/main_cli.cpp
+++ b/main_cli.cpp
@@ -42,14 +42,12 @@
 #include "mc_enum_types_aux.hpp"        // allowed_strings_emission(), mc_emission_from_string()
 #include "mec_server.hpp"
 #include "miscellany.hpp"
+#include "path.hpp"
 #include "path_utility.hpp"
 #include "so_attributes.hpp"
 #include "timer.hpp"
 #include "value_cast.hpp"
 #include "verify_products.hpp"
-
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <algorithm>                    // for_each()
 #include <cmath>                        // fabs()

--- a/main_common.cpp
+++ b/main_common.cpp
@@ -59,9 +59,6 @@ extern "C" unsigned int _get_output_format(void) {return 1;}
 /// Common application initialization.
 ///
 /// Also see the similar code in 'cpp_main.cpp' (for unit tests).
-///
-/// Don't initialize boost::filesystem here, to avoid creating a
-/// dependency on its object files for applications that don't use it.
 
 void initialize_application()
 {

--- a/main_common_non_wx.cpp
+++ b/main_common_non_wx.cpp
@@ -38,9 +38,6 @@
 /// Exception: for msw at least, wx doesn't use main(). The way
 /// diagnostic messages are displayed for wx is different enough to
 /// warrant a parallel implementation.
-///
-/// Don't initialize boost::filesystem here, to avoid creating a
-/// dependency on its object files for applications that don't use it.
 
 int main(int argc, char* argv[])
 {

--- a/main_wx.cpp
+++ b/main_wx.cpp
@@ -36,7 +36,6 @@
 #include "force_linking.hpp"
 #include "handle_exceptions.hpp"
 #include "main_common.hpp"              // initialize_application()
-#include "path_utility.hpp"             // initialize_filesystem()
 #include "skeleton.hpp"
 
 #include <wx/init.h>                    // wxEntry()
@@ -88,7 +87,6 @@ int WINAPI WinMain
     try
         {
         initialize_application();
-        initialize_filesystem();
 #if !defined LMI_MSW
         result = wxEntry(argc, argv);
 #else  // defined LMI_MSW

--- a/main_wx_test.cpp
+++ b/main_wx_test.cpp
@@ -28,6 +28,7 @@
 #include "force_linking.hpp"
 #include "handle_exceptions.hpp"        // stealth_exception
 #include "main_common.hpp"              // initialize_application()
+#include "path.hpp"
 #include "skeleton.hpp"
 #include "ssize_lmi.hpp"                // sstrlen()
 #include "wx_test_case.hpp"
@@ -42,9 +43,6 @@
 #include <wx/testing.h>
 #include <wx/uiaction.h>
 #include <wx/wfstream.h>
-
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <algorithm>                    // sort()
 #include <cstring>                      // strcmp()

--- a/main_wx_test.cpp
+++ b/main_wx_test.cpp
@@ -28,7 +28,6 @@
 #include "force_linking.hpp"
 #include "handle_exceptions.hpp"        // stealth_exception
 #include "main_common.hpp"              // initialize_application()
-#include "path_utility.hpp"             // initialize_filesystem()
 #include "skeleton.hpp"
 #include "ssize_lmi.hpp"                // sstrlen()
 #include "wx_test_case.hpp"
@@ -925,7 +924,6 @@ void SkeletonTest::RunTheTests()
 int main(int argc, char* argv[])
 {
     initialize_application();
-    initialize_filesystem();
 
     if(!application_test::instance().process_command_line(argc, argv))
         {

--- a/main_wx_test.cpp
+++ b/main_wx_test.cpp
@@ -414,7 +414,7 @@ bool application_test::process_command_line(int& argc, char* argv[])
         {
         warning()
             << "Test files path '"
-            << test_files_path_.native_file_string()
+            << test_files_path_
             << "' doesn't exist."
             << std::flush
             ;
@@ -563,7 +563,7 @@ fs::path wx_base_test_case::get_test_files_path() const
 std::string
 wx_base_test_case::get_test_file_path_for(std::string const& basename) const
 {
-    return (get_test_files_path() / basename).native_file_string();
+    return (get_test_files_path() / basename).string();
 }
 
 bool wx_base_test_case::is_distribution_test() const

--- a/main_wx_test.cpp
+++ b/main_wx_test.cpp
@@ -422,7 +422,7 @@ bool application_test::process_command_line(int& argc, char* argv[])
         }
     else
         {
-        test_files_path_ = fs::system_complete(test_files_path_);
+        test_files_path_ = fs::absolute(test_files_path_);
         }
 
     return true;

--- a/md5sum.hpp
+++ b/md5sum.hpp
@@ -23,8 +23,7 @@
 #define md5sum_hpp
 
 #include "config.hpp"
-
-#include <boost/filesystem/path.hpp>
+#include "path.hpp"
 
 #include <climits>                      // CHAR_BIT
 #include <iosfwd>

--- a/md5sum_test.cpp
+++ b/md5sum_test.cpp
@@ -22,10 +22,8 @@
 #include "pchfile.hpp"
 
 #include "md5sum.hpp"
+#include "path.hpp"
 #include "test_tools.hpp"
-
-#include <boost/filesystem/operations.hpp> // fs::exists()
-#include <boost/filesystem/path.hpp>
 
 #include <cstdio>                       // remove()
 #include <fstream>

--- a/mec_server.cpp
+++ b/mec_server.cpp
@@ -520,7 +520,7 @@ bool mec_server::operator()(fs::path const& file_path, mec_input const& z)
     timer.restart();
     if(mce_emit_test_data & emission_)
         {
-        state_.save(fs::change_extension(file_path, ".mec.xml"));
+        state_.save(fs::path{file_path}.replace_extension(".mec.xml"));
         }
     seconds_for_output_       = timer.stop().elapsed_seconds();
     conditionally_show_timings_on_stdout();

--- a/mec_server.cpp
+++ b/mec_server.cpp
@@ -42,6 +42,7 @@
 #include "mec_xml_document.hpp"
 #include "miscellany.hpp"               // each_equal(), ios_out_trunc_binary()
 #include "oecumenic_enumerations.hpp"
+#include "path.hpp"
 #include "path_utility.hpp"             // unique_filepath(), fs::path inserter
 #include "premium_tax.hpp"
 #include "product_data.hpp"
@@ -51,9 +52,6 @@
 #include "stratified_charges.hpp"
 #include "timer.hpp"
 #include "value_cast.hpp"
-
-#include <boost/filesystem/convenience.hpp> // extension(), change_extension()
-#include <boost/filesystem/fstream.hpp>
 
 #include <algorithm>                    // min()
 #include <iostream>

--- a/mec_server.cpp
+++ b/mec_server.cpp
@@ -490,7 +490,7 @@ mec_server::mec_server(mcenum_emission emission) : emission_(emission)
 
 bool mec_server::operator()(fs::path const& file_path)
 {
-    std::string const extension = fs::extension(file_path);
+    std::string const extension = file_path.extension().string();
     if(".mec" == extension)
         {
         Timer timer;

--- a/mec_server.hpp
+++ b/mec_server.hpp
@@ -26,9 +26,8 @@
 
 #include "mc_enum_type_enums.hpp"       // enum mcenum_emission
 #include "mec_state.hpp"
+#include "path.hpp"
 #include "so_attributes.hpp"
-
-#include <boost/filesystem/path.hpp>
 
 class mec_input;
 

--- a/mec_state.cpp
+++ b/mec_state.cpp
@@ -27,10 +27,9 @@
 #include "alert.hpp"
 #include "contains.hpp"
 #include "miscellany.hpp"               // htmlize()
+#include "path.hpp"
 #include "value_cast.hpp"
 #include "xml_lmi.hpp"
-
-#include <boost/filesystem/fstream.hpp>
 
 #include <limits>
 #include <sstream>

--- a/name_value_pairs_test.cpp
+++ b/name_value_pairs_test.cpp
@@ -33,7 +33,7 @@
 
 int test_main(int, char*[])
 {
-    std::string const tmp = "/tmp/" + fs::basename(__FILE__);
+    std::string const tmp = "/tmp/" + fs::path{__FILE__}.stem().string();
     fs::path const tmpdir(fs::absolute(tmp));
     fs::create_directory(tmpdir);
 

--- a/name_value_pairs_test.cpp
+++ b/name_value_pairs_test.cpp
@@ -34,7 +34,7 @@
 int test_main(int, char*[])
 {
     std::string const tmp = "/tmp/" + fs::basename(__FILE__);
-    fs::path const tmpdir(fs::complete(tmp));
+    fs::path const tmpdir(fs::absolute(tmp));
     fs::create_directory(tmpdir);
 
     std::string filename0(tmp + "/eraseme");

--- a/name_value_pairs_test.cpp
+++ b/name_value_pairs_test.cpp
@@ -24,11 +24,8 @@
 #include "name_value_pairs.hpp"
 
 #include "miscellany.hpp"
+#include "path.hpp"
 #include "test_tools.hpp"
-
-#include <boost/filesystem/convenience.hpp> // basename()
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <cstdio>                       // remove()
 #include <fstream>

--- a/path.hpp
+++ b/path.hpp
@@ -1,0 +1,413 @@
+// The path class.
+//
+// Copyright (C) 2020 Gregory W. Chicares.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//
+// https://savannah.nongnu.org/projects/lmi
+// email: <gchicares@sbcglobal.net>
+// snail: Chicares, 186 Belle Woods Drive, Glastonbury CT 06033, USA
+
+#ifndef path_hpp
+#define path_hpp
+
+#include "config.hpp"
+
+#include "so_attributes.hpp"
+
+#include <filesystem>
+#include <ostream>
+#include <string>
+#include <system_error> // std::error_code
+
+namespace fs
+{
+
+/// Using the classes from std::filesystem.
+
+using std::filesystem::directory_entry;
+using std::filesystem::directory_iterator;
+using std::filesystem::file_time_type;
+using std::filesystem::filesystem_error;
+
+/// Using the functions, which takes the path as an argument to
+/// allow passing std::string to them.
+
+using std::filesystem::create_directory;
+using std::filesystem::exists;
+using std::filesystem::is_directory;
+using std::filesystem::last_write_time;
+using std::filesystem::remove;
+using std::filesystem::rename;
+
+/// The path class.
+///
+/// Motivation.
+/// Implement own operator<<, which doesn't wrap the path with the double
+/// quotes, like std::filesystem::path::operator<< does.
+/// Also always use UTF8 encoding when construct from the string and allow
+/// convetring to the string only with UFT8 encoding.
+
+class LMI_SO path
+{
+  public:
+    /// Constructors and destructor.
+
+    path() noexcept = default;
+
+    path(path const& p)
+        :path_{p.path_}
+        {
+        }
+
+    path(path&& p) noexcept
+        :path_{std::move(p.path_)}
+        {
+        }
+
+    path(std::filesystem::path const& p)
+        :path_{p}
+        {
+        }
+
+    path(std::filesystem::path&& p) noexcept
+        :path_{std::move(p)}
+        {
+        }
+
+    path(std::string const& source)
+        :path_{std::filesystem::u8path(source)}
+        {
+        }
+
+    path(char const* source)
+        :path_{std::filesystem::u8path(source)}
+        {
+        }
+
+    ~path() = default;
+ 
+    /// Assignments.
+
+    path& operator=(path const& p)
+        {
+        path_ = p.path_;
+        return *this;
+        }
+
+    path& operator=(path&& p) noexcept
+        {
+        path_ = std::move(p.path_);
+        return *this;
+        }
+
+    path& operator=(std::filesystem::path const& p) noexcept
+        {
+        path_ = p;
+        return *this;
+        }
+
+    path& operator=(std::filesystem::path&& p) noexcept
+        {
+        path_ = std::move(p);
+        return *this;
+        }
+
+    path& operator=(std::string const& source)
+        {
+        path_ = std::filesystem::u8path(source);
+        return *this;
+        }
+
+    path& operator=(char const* source)
+        {
+        path_ = std::filesystem::u8path(source);
+        return *this;
+        }
+ 
+    /// Appends.
+
+    path& operator/=(path const& p)
+        {
+        path_ /= p.path_;
+        return *this;
+        }
+
+    path& operator/=(std::string const& source)
+        {
+        path_ /= source;
+        return *this;
+        }
+ 
+    /// Modifiers.
+
+    void clear() noexcept
+        {
+        path_.clear();
+        }
+
+    path& make_preferred()
+        {
+        path_.make_preferred();
+        return *this;
+        }
+
+    path& remove_filename()
+        {
+        path_.remove_filename();
+        return *this;
+        }
+
+    path& replace_filename(const path& replacement)
+        {
+        path_.replace_filename(replacement.path_);
+        return *this;
+        }
+
+    path& replace_extension(const path& replacement = path())
+        {
+        path_.replace_extension(replacement.path_);
+        return *this;
+        }
+
+    void swap(path& rhs) noexcept
+        {
+        path_.swap(rhs.path_);
+        }
+ 
+    /// Native format observer.
+
+    operator std::filesystem::path() const
+        {
+        return path_;
+        }
+
+    /// The function is used only in native_path(). Returns the UFT8 string
+    /// with the native separators ('\\' under Windows).
+    /// Note that the corresponding function doesn't exist in
+    /// std::filesystem::path class.
+
+    std::string native_string() const
+        {
+        // make_preferred() changes the path, so make copy of path_.
+        std::filesystem::path tmp{path_};
+        return tmp.make_preferred().u8string();
+        }
+ 
+    /// Returns the UFT8 encoded string in the lexically normalized generic
+    /// format. The functionality differs from the standard one to use the
+    /// short and simple function name which is used in most of cases.
+
+    std::string string() const
+        {
+        return path_.lexically_normal().generic_u8string();
+        }
+
+    /// Generation.
+
+    path lexically_normal() const
+        {
+        return path_.lexically_normal();
+        }
+
+    path lexically_relative(const path& base) const
+        {
+        return path_.lexically_relative(base.path_);
+        }
+
+    path lexically_proximate(const path& base) const
+        {
+        return path_.lexically_proximate(base.path_);
+        }
+
+    /// Decomposition.
+
+    path root_name() const
+        {
+        return path_.root_name();
+        }
+
+    path root_directory() const
+        {
+        return path_.root_directory();
+        }
+
+    path root_path() const
+        {
+        return path_.root_path();
+        }
+
+    path relative_path() const
+        {
+        return path_.relative_path();
+        }
+
+    path parent_path() const
+        {
+        return path_.parent_path();
+        }
+
+    path filename() const
+        {
+        return path_.filename();
+        }
+
+    path stem() const
+        {
+        return path_.stem();
+        }
+
+    path extension() const
+        {
+        return path_.extension();
+        }
+ 
+    /// Query.
+
+    [[nodiscard]] bool empty() const noexcept
+        {
+        return path_.empty();
+        }
+
+    [[nodiscard]] bool has_root_name() const
+        {
+        return path_.has_root_name();
+        }
+
+    [[nodiscard]] bool has_root_directory() const
+        {
+        return path_.has_root_directory();
+        }
+
+    [[nodiscard]] bool has_root_path() const
+        {
+        return path_.has_root_path();
+        }
+
+    [[nodiscard]] bool has_relative_path() const
+        {
+        return path_.has_relative_path();
+        }
+
+    [[nodiscard]] bool has_parent_path() const
+        {
+        return path_.has_parent_path();
+        }
+
+    [[nodiscard]] bool has_filename() const
+        {
+        return path_.has_filename();
+        }
+
+    [[nodiscard]] bool has_stem() const
+        {
+        return path_.has_stem();
+        }
+
+    [[nodiscard]] bool has_extension() const
+        {
+        return path_.has_extension();
+        }
+
+    [[nodiscard]] bool is_absolute() const
+        {
+        return path_.is_absolute();
+        }
+
+    [[nodiscard]] bool is_relative() const
+        {
+        return path_.is_relative();
+        }
+
+  private:
+    std::filesystem::path path_;
+
+    friend bool operator==(const path& lhs, const path& rhs) noexcept;
+    friend bool operator!=(const path& lhs, const path& rhs) noexcept;
+    friend bool operator<(const path& lhs, const path& rhs) noexcept;
+    friend bool operator<=(const path& lhs, const path& rhs) noexcept;
+    friend bool operator>(const path& lhs, const path& rhs) noexcept;
+    friend bool operator>=(const path& lhs, const path& rhs) noexcept;
+    friend path operator/(const path& lhs, const path& rhs);
+};
+
+/// Non-member operators.
+
+inline bool operator==(const path& lhs, const path& rhs) noexcept
+{
+    return lhs.path_ == rhs.path_;
+}
+
+inline bool operator!=(const path& lhs, const path& rhs) noexcept
+{
+    return lhs.path_ != rhs.path_;
+}
+
+inline bool operator<(const path& lhs, const path& rhs) noexcept
+{
+    return lhs.path_ < rhs.path_;
+}
+
+inline bool operator<=(const path& lhs, const path& rhs) noexcept
+{
+    return lhs.path_ <= rhs.path_;
+}
+
+inline bool operator>(const path& lhs, const path& rhs) noexcept
+{
+    return lhs.path_ > rhs.path_;
+}
+
+inline bool operator>=(const path& lhs, const path& rhs) noexcept
+{
+    return lhs.path_ >= rhs.path_;
+}
+
+inline path operator/(const path& lhs, const path& rhs)
+{
+    return lhs.path_ / rhs.path_;
+}
+
+template<class CharT, class Traits>
+inline std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const path& p)
+{
+    return os << p.string();
+}
+
+/// Implement own functions, which return the path.
+
+inline path absolute(const path& p)
+{
+    return std::filesystem::absolute(p);
+}
+
+inline path absolute(const path& p, std::error_code& ec)
+{
+    return std::filesystem::absolute(p, ec);
+}
+
+inline path current_path()
+{
+    return std::filesystem::current_path();
+}
+
+inline path current_path(std::error_code& ec)
+{
+    return std::filesystem::current_path(ec);
+}
+
+} // namespace fs
+
+#endif // path_hpp

--- a/path.hpp
+++ b/path.hpp
@@ -27,6 +27,7 @@
 #include "so_attributes.hpp"
 
 #include <filesystem>
+#include <fstream>
 #include <ostream>
 #include <string>
 #include <system_error> // std::error_code
@@ -407,6 +408,82 @@ inline path current_path(std::error_code& ec)
 {
     return std::filesystem::current_path(ec);
 }
+
+/// File streams.
+///
+/// Motivation: our own file streams can be constructed from our own path
+/// class. fs::path has `operator std::filesystem::path()`, but the following
+/// code fails:
+///
+/// fs::path p{"file.ext"};
+/// fs::ifstream s{p};
+///
+/// So implement our own classes for the exact match of constructor parameters.
+///
+/// Note that fs::path can be constructed from a string using fs::u8path()
+/// which leads to differences with the standard file streams constructing:
+///
+/// std::string filename{"unicode_filename.ext"};
+/// fs::ifstream fs1 {filename}; // The filename treated as UTF8 encoded.
+/// std::ifstream fs2{filename}; // Used the current locale.
+
+class LMI_SO ifstream final
+    :public std::ifstream
+{
+  public:
+    ifstream() = default;
+
+    explicit ifstream
+        (path const& p
+        ,std::ios_base::openmode mode = std::ios_base::in
+        )
+        :std::ifstream(static_cast<std::filesystem::path const&>(p), mode)
+        {
+        }
+
+    ifstream(ifstream const&) = delete;
+    ifstream(ifstream&&) = default;
+
+    void open
+        (path const& p
+        ,std::ios_base::openmode mode = std::ios_base::in
+        )
+        {
+            std::ifstream::open
+                (static_cast<std::filesystem::path const&>(p)
+                ,mode
+                );
+        }
+};
+
+class LMI_SO ofstream final
+    :public std::ofstream
+{
+  public:
+    ofstream() = default;
+
+    explicit ofstream
+        (path const& p
+        ,std::ios_base::openmode mode = std::ios_base::out
+        )
+        :std::ofstream(static_cast<std::filesystem::path const&>(p), mode)
+        {
+        }
+
+    ofstream(ofstream const&) = delete;
+    ofstream(ofstream&&) = default;
+
+    void open
+        (path const& p
+        ,std::ios_base::openmode mode = std::ios_base::out
+        )
+        {
+        std::ofstream::open
+            (static_cast<std::filesystem::path const&>(p)
+            ,mode
+            );
+        }
+};
 
 } // namespace fs
 

--- a/path_utility.cpp
+++ b/path_utility.cpp
@@ -27,10 +27,7 @@
 #include "assert_lmi.hpp"
 #include "global_settings.hpp"
 #include "miscellany.hpp"               // iso_8601_datestamp_terse()
-
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem/exception.hpp>
-#include <boost/filesystem/operations.hpp>
+#include "path.hpp"
 
 #include <cctype>                       // isalnum()
 #include <exception>

--- a/path_utility.cpp
+++ b/path_utility.cpp
@@ -37,62 +37,6 @@
 #include <iomanip>
 #include <sstream>
 
-/// Preserve initial path and set "native" name-checking policy for
-/// boost filesystem library.
-///
-/// Applications that end users would normally run should call this
-/// function during initialization--before using this boost library
-/// in any other way, to ensure uniform name checking (which enables
-/// them to use nonportable paths, as some demand), and to make it
-/// potentially possible to protect them somewhat from the strange
-/// effects of inadvertent changes to the current working directory.
-/// As boost's documentation notes, msw may resolve relative paths as
-///   "complete( path, kinky ), where kinky is the current directory
-///   for the [path's] drive. This will be the current directory of
-///   that drive the last time it was set, and thus may well be
-///   residue left over from some prior program run by the command
-///   processor! Although these semantics are often useful, they are
-///   also very error-prone, and certainly deserve to be called
-///   'kinky'."
-/// although it's unclear whether there's any way to get msw to do
-/// this exactly when end users desire it and not otherwise.
-///
-/// Call this function during initialization for any program that
-/// could be passed a path argument, even if the argument is a
-/// portable path. Motivating case: MSYS's bash translated it to a
-/// nonportable path; e.g., if this function wasn't called, then
-///   --data_path='/opt/lmi/data'
-/// engendered this diagnostic:
-///   boost::filesystem::path: [line split for readability]
-///     invalid name "C:" in path: "C:/msys/1.0/opt/lmi/data"
-/// Keep doing this for future-proofing even though MSYS is no longer
-/// supported.
-///
-/// This function is not called in the initialization routine used by
-/// all programs, because simple command-line tools should not be
-/// forced to depend on this boost library.
-///
-/// Resist the urge to write its simple implementation inline because
-/// that may fail with gcc on msw--see:
-///   http://article.gmane.org/gmane.comp.gnu.mingw.user/18633
-///     [2006-01-14T11:55:49Z from Greg Chicares]
-///
-/// The boost documentation says:
-///   "The preferred implementation would be to call initial_path()
-///   during program initialization, before the call to main().
-///   This is, however, not possible with changing the C++ runtime
-///   library."
-/// One could wish that they had expressed that in code instead of
-/// commentary: std::cout manages to work this way by using the
-/// so-called "nifty counter" technique, which perhaps ought to be
-/// used here.
-
-void initialize_filesystem()
-{
-    fs::path::default_name_check(fs::native);
-    fs::initial_path();
-}
-
 /// Change '/path/to/file' to '/some/other/place/file'.
 ///
 /// Motivation: It is anomalous that boost permits this:

--- a/path_utility.cpp
+++ b/path_utility.cpp
@@ -268,7 +268,7 @@ fs::path unique_filepath
     catch(std::exception const&)
         {
         std::string basename  = fs::basename (filepath);
-        std::string extension = fs::extension(filepath);
+        std::string const extension = filepath.extension().string();
         basename += '-' + iso_8601_datestamp_terse() + extension;
         filepath = filepath.branch_path() / basename;
         if(fs::exists(filepath))

--- a/path_utility.cpp
+++ b/path_utility.cpp
@@ -109,7 +109,7 @@ fs::path LMI_SO modify_directory
 ///   http://www.cantrip.org/coding-standard2.html
 /// would prefer a predicate phrase like is_portable_file_name():
 /// cf. std::isalnum(), std::numeric_limits::is_signed(), and even
-/// boost::filesystem::is_complete().
+/// std::filesystem::path::is_absolute().
 
 std::string orthodox_filename(std::string const& original_filename)
 {
@@ -189,7 +189,7 @@ std::string serial_extension
 ///
 /// It is necessary to call orthodox_filename() on the insured's name
 /// in case it contains a character (probably whitespace) that might
-/// fail a boost::filesystem name check.
+/// fail a std::filesystem name check.
 
 fs::path serial_file_path
     (fs::path    const& exemplar

--- a/path_utility.cpp
+++ b/path_utility.cpp
@@ -101,14 +101,6 @@ fs::path LMI_SO modify_directory
 /// in case an end user types something like
 ///   Crime and/or Punishment
 /// with no intention of denoting a path.
-///
-/// Although portable_filename() would be a better name, that would be
-/// confusing because the boost filesystem library already provides
-/// boolean predicates like portable_file_name(), where Myers
-///   http://www.cantrip.org/coding-standard2.html
-/// would prefer a predicate phrase like is_portable_file_name():
-/// cf. std::isalnum(), std::numeric_limits::is_signed(), and even
-/// std::filesystem::path::is_absolute().
 
 std::string orthodox_filename(std::string const& original_filename)
 {

--- a/path_utility.cpp
+++ b/path_utility.cpp
@@ -36,11 +36,11 @@
 
 /// Change '/path/to/file' to '/some/other/place/file'.
 ///
-/// Motivation: It is anomalous that boost permits this:
+/// Motivation: It is anomalous that std::filesystem permits this:
 ///   path file("/bin/sh";
 ///   path dir ("/usr/bin");
-///   dir / path; // returns "/usr/bin/bin/sh"
-/// where true == file.is_complete().
+///   dir / path; // returns "/bin/sh"
+/// where true == file.is_absolute().
 ///
 /// Arguably the arguments should be given in the opposite order:
 ///   modify_directory("sh", "/usr/bin") // present order
@@ -62,14 +62,13 @@
 /// It is notably not required that 'supplied_directory' name an
 /// actual existing directory.
 ///
-/// Boost provides no way to test whether a path has the form of a
-/// directory. Its fs::is_directory() asks the operating system:
+/// std::filesystem provides no way to test whether a path has the form
+/// of a directory. Its fs::is_directory() asks the operating system:
 ///   is_directory("/usr/lib")
 /// returns 'true' iff the OS reports that such a directory exists;
 /// but the same function call would return 'false' after
 ///   rm -rf /usr/lib ; touch /usr/lib
-/// Notably, path("/bin/sh/") succeeds, silently discarding the
-/// trailing '/'.
+/// Notably, path("/bin/sh/") fails because it hasn't the filename.
 
 fs::path LMI_SO modify_directory
     (fs::path const& original_filepath

--- a/path_utility.cpp
+++ b/path_utility.cpp
@@ -269,7 +269,7 @@ fs::path unique_filepath
         std::string basename  = filepath.stem().string();
         std::string const extension = filepath.extension().string();
         basename += '-' + iso_8601_datestamp_terse() + extension;
-        filepath = filepath.branch_path() / basename;
+        filepath = filepath.parent_path() / basename;
         if(fs::exists(filepath))
             {
             alarum()

--- a/path_utility.cpp
+++ b/path_utility.cpp
@@ -58,7 +58,7 @@
 /// evokes chdir(2) and cd(1).
 ///
 /// Asserted precondition:
-///   - 'original_filepath' is not empty (i.e., true == has_leaf())
+///   - 'original_filepath' is not empty (i.e., true == has_filename())
 /// It is notably not required that 'supplied_directory' name an
 /// actual existing directory.
 ///
@@ -76,7 +76,7 @@ fs::path LMI_SO modify_directory
     ,fs::path const& supplied_directory
     )
 {
-    LMI_ASSERT(original_filepath.has_leaf());
+    LMI_ASSERT(original_filepath.has_filename());
     return supplied_directory / fs::path(original_filepath.leaf());
 }
 
@@ -200,7 +200,7 @@ fs::path serial_file_path
     )
 {
     LMI_ASSERT(!exemplar.empty());
-    LMI_ASSERT(exemplar.has_leaf());
+    LMI_ASSERT(exemplar.has_filename());
     std::string s(serial_extension(serial_number, extension));
     if
         (  !personal_name.empty()

--- a/path_utility.cpp
+++ b/path_utility.cpp
@@ -267,7 +267,7 @@ fs::path unique_filepath
         }
     catch(std::exception const&)
         {
-        std::string basename  = fs::basename (filepath);
+        std::string basename  = filepath.stem().string();
         std::string const extension = filepath.extension().string();
         basename += '-' + iso_8601_datestamp_terse() + extension;
         filepath = filepath.branch_path() / basename;

--- a/path_utility.cpp
+++ b/path_utility.cpp
@@ -300,9 +300,8 @@ namespace
 /// appropriate here, std::runtime_error (via alarum()) is chosen
 /// because the 'a_path' argument may be specified by users.
 ///
-/// Exceptions thrown from the boost filesystem library on path
-/// assignment are caught in order to rethrow with 'context'
-/// prepended.
+/// Note that std::filesystem::path constructor doesn't throws even
+/// if the path is not allowed to exist on the current file system or OS.
 ///
 /// Design alternative: instead of calling this function from
 /// validate_directory() and validate_filepath(), eliminate those
@@ -315,15 +314,7 @@ void validate_path
     ,std::string const& context
     )
 {
-    fs::path path;
-    try
-        {
-        path = a_path;
-        }
-    catch(fs::filesystem_error const& e)
-        {
-        alarum() << context << ": " << e.what() << LMI_FLUSH;
-        }
+    fs::path path{a_path};
 
     if(path.empty())
         {

--- a/path_utility.cpp
+++ b/path_utility.cpp
@@ -45,7 +45,7 @@
 /// Arguably the arguments should be given in the opposite order:
 ///   modify_directory("sh", "/usr/bin") // present order
 ///   modify_directory("/usr/bin", "sh") // opposite order
-/// because the path precedes the leaf in canonical form. However,
+/// because the path precedes the filename in canonical form. However,
 /// fs::path::replace_extension() uses the present argument order:
 ///   original.replace_extension(new_part)
 /// and in a nondegenerate case such as:
@@ -77,7 +77,7 @@ fs::path LMI_SO modify_directory
     )
 {
     LMI_ASSERT(original_filepath.has_filename());
-    return supplied_directory / fs::path(original_filepath.leaf());
+    return supplied_directory / original_filepath.filename();
 }
 
 /// Return a filename appropriate for posix as well as msw.
@@ -181,12 +181,11 @@ std::string serial_extension
 /// output filenames simpler and more regular, yet doesn't suppress
 /// any information that would actually be useful.
 ///
-/// Preconditions: census input filepath is nonempty and has a leaf.
-/// It's not apparent how a nonempty path could fail to have a leaf,
-/// but presumably boost has some undocumented reason.
+/// Preconditions: census input filepath is nonempty and has a filename.
+/// For example `path/without/name/` is nonempty but hasn't the filename.
 ///
 /// Any extension or path is discarded from the input census filepath;
-/// only the filename leaf is used.
+/// only the filename is used.
 ///
 /// It is necessary to call orthodox_filename() on the insured's name
 /// in case it contains a character (probably whitespace) that might
@@ -209,7 +208,7 @@ fs::path serial_file_path
         {
         s = '.' + orthodox_filename(personal_name) + s;
         }
-    return fs::path{exemplar.leaf()}.replace_extension(s);
+    return fs::path{exemplar}.filename().replace_extension(s);
 }
 
 /// Create a unique file path, following input as closely as possible.

--- a/path_utility.cpp
+++ b/path_utility.cpp
@@ -46,8 +46,8 @@
 ///   modify_directory("sh", "/usr/bin") // present order
 ///   modify_directory("/usr/bin", "sh") // opposite order
 /// because the path precedes the leaf in canonical form. However,
-/// fs::change_extension() uses the present argument order:
-///   function(original, new_part)
+/// fs::path::replace_extension() uses the present argument order:
+///   original.replace_extension(new_part)
 /// and in a nondegenerate case such as:
 ///   modify_directory("/bin/sh", "/usr/bin") // present order
 /// simply means "change the directory of /bin/sh to /usr/bin", while
@@ -209,7 +209,7 @@ fs::path serial_file_path
         {
         s = '.' + orthodox_filename(personal_name) + s;
         }
-    return fs::change_extension(exemplar.leaf(), s);
+    return fs::path{exemplar.leaf()}.replace_extension(s);
 }
 
 /// Create a unique file path, following input as closely as possible.
@@ -254,7 +254,7 @@ fs::path unique_filepath
     )
 {
     fs::path filepath(original_filepath);
-    filepath = fs::change_extension(filepath, supplied_extension);
+    filepath.replace_extension(supplied_extension);
     if(!fs::exists(filepath))
         {
         return filepath;

--- a/path_utility.cpp
+++ b/path_utility.cpp
@@ -236,8 +236,7 @@ fs::path serial_file_path
 ///
 /// A try-block is necessary because fs::remove() can throw. The
 /// postcondition is asserted explicitly at the end of the try-block
-/// because that boost function's semantics have changed between
-/// versions, and its documentation is still unclear in boost-1.34:
+/// because that fs::remove() documentation is still unclear:
 /// apparently it mustn't fail without throwing, yet it doesn't throw
 /// on an operation that must fail, like removing a file that's locked
 /// by another process as in the motivating example above.

--- a/path_utility.hpp
+++ b/path_utility.hpp
@@ -24,9 +24,8 @@
 
 #include "config.hpp"
 
+#include "path.hpp"
 #include "so_attributes.hpp"
-
-#include <boost/filesystem/path.hpp>
 
 #include <ostream>
 #include <string>

--- a/path_utility.hpp
+++ b/path_utility.hpp
@@ -64,17 +64,4 @@ void LMI_SO validate_filepath
     ,std::string const& context
     );
 
-namespace boost
-{
-namespace filesystem
-{
-
-inline std::ostream& operator<<(std::ostream& os, fs::path const& z)
-{
-    return os << z.string();
-}
-
-} // namespace filesystem
-} // namespace boost
-
 #endif // path_utility_hpp

--- a/path_utility.hpp
+++ b/path_utility.hpp
@@ -31,8 +31,6 @@
 #include <ostream>
 #include <string>
 
-void LMI_SO initialize_filesystem(); // Listed first because of its importance.
-
 fs::path LMI_SO modify_directory
     (fs::path const& original_filepath
     ,fs::path const& supplied_directory

--- a/path_utility_test.cpp
+++ b/path_utility_test.cpp
@@ -24,14 +24,9 @@
 #include "path_utility.hpp"
 
 #include "miscellany.hpp"
+#include "path.hpp"
 #include "platform_dependent.hpp"       // access()
 #include "test_tools.hpp"
-
-#include <boost/filesystem/convenience.hpp> // basename()
-#include <boost/filesystem/exception.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <cstdio>                       // remove()
 #include <fstream>

--- a/path_utility_test.cpp
+++ b/path_utility_test.cpp
@@ -78,7 +78,7 @@ void test_modify_directory()
     BOOST_TEST_THROW
         (modify_directory("", "/bin")
         ,std::runtime_error
-        ,"Assertion 'original_filepath.has_leaf()' failed."
+        ,"Assertion 'original_filepath.has_filename()' failed."
         );
 }
 

--- a/path_utility_test.cpp
+++ b/path_utility_test.cpp
@@ -70,10 +70,12 @@ void test_modify_directory()
     BOOST_TEST_EQUAL("sh"           , modify_directory("sh"     , ""        ).string());
     BOOST_TEST_EQUAL("sh"           , modify_directory("/bin/sh", ""        ).string());
 
-    // Arguably this should be forbidden:
-    //   $ls /bin/sh/
-    //   ls: cannot access '/bin/sh/': Not a directory
-    BOOST_TEST_EQUAL("/bin/sh"      , modify_directory("sh/"    , "/bin/"   ).string());
+    // "sh/" hasn't the filename.
+    BOOST_TEST_THROW
+        (modify_directory("sh/", "/bin/")
+        ,std::runtime_error
+        ,"Assertion 'original_filepath.has_filename()' failed."
+        );
 
     BOOST_TEST_THROW
         (modify_directory("", "/bin")

--- a/path_utility_test.cpp
+++ b/path_utility_test.cpp
@@ -167,7 +167,7 @@ void test_unique_filepath_with_normal_filenames()
     // as a substitute for the nonstandard mkstemp() is a bad idea.
     // See:
     //   https://lists.nongnu.org/archive/html/lmi/2020-08/msg00015.html
-    fs::path const u = unique_filepath("/tmp/" + fs::basename(__FILE__), "");
+    fs::path const u = unique_filepath("/tmp/" + fs::path{__FILE__}.stem().string(), "");
     std::string const tmp = u.string();
     fs::path const tmpdir(fs::absolute(tmp));
     fs::create_directory(tmpdir);

--- a/path_utility_test.cpp
+++ b/path_utility_test.cpp
@@ -385,8 +385,6 @@ void test_path_validation()
 
 int test_main(int, char*[])
 {
-    initialize_filesystem();
-
     test_modify_directory();
     test_orthodox_filename();
     test_serial_file_path();

--- a/path_utility_test.cpp
+++ b/path_utility_test.cpp
@@ -169,7 +169,7 @@ void test_unique_filepath_with_normal_filenames()
     //   https://lists.nongnu.org/archive/html/lmi/2020-08/msg00015.html
     fs::path const u = unique_filepath("/tmp/" + fs::basename(__FILE__), "");
     std::string const tmp = u.string();
-    fs::path const tmpdir(fs::complete(tmp));
+    fs::path const tmpdir(fs::absolute(tmp));
     fs::create_directory(tmpdir);
 
     // These tests would fail if read-only files with the following
@@ -323,7 +323,7 @@ void test_path_validation()
     // Create a file and a directory to test.
     //
     // Another test that calls fs::create_directory() uses an absolute
-    // path that's uniquified and canonicalized with fs::complete().
+    // path that's uniquified and canonicalized with fs::absolute().
     // This call uses a relative path, with no such safeguards; this
     // being a unit test, it is appropriate to retain some fragility.
     // If one user runs this test, and the directory created here

--- a/path_utility_test.cpp
+++ b/path_utility_test.cpp
@@ -289,11 +289,9 @@ void test_unique_filepath_with_ludicrous_filenames()
     fs::path path2 = unique_filepath(fs::path(""), "");
     BOOST_TEST_EQUAL(path2.string(), "");
 
-    BOOST_TEST_THROW
-        (unique_filepath(fs::path(".."), "..")
-        ,fs::filesystem_error
-        ,""
-        );
+    // std::filesystem allows fs::path{".."}.replace_extension("..").
+    fs::path path3 = unique_filepath(fs::path(".."), "..");
+    BOOST_TEST_EQUAL(path3.string(), "....");
 }
 
 void test_path_inserter()

--- a/path_utility_test.cpp
+++ b/path_utility_test.cpp
@@ -340,7 +340,7 @@ void test_path_validation()
     BOOST_TEST_THROW
         (validate_filepath("<|>", context)
         ,std::runtime_error
-        ,lmi_test::what_regex("invalid name \"<|>\" in path")
+        ,"Unit test file '<|>' not found."
         );
 
     // Not empty.

--- a/pdf_command.hpp
+++ b/pdf_command.hpp
@@ -24,9 +24,8 @@
 
 #include "config.hpp"
 
+#include "path.hpp"
 #include "so_attributes.hpp"
-
-#include <boost/filesystem/path.hpp>
 
 class Ledger;
 

--- a/preferences_model.cpp
+++ b/preferences_model.cpp
@@ -71,16 +71,11 @@ std::string generic_path(std::string const& s)
 /// counterpart generic_path() are used to translate between the two
 /// styles, so that backward slashes are sequestered in the GUI and do
 /// not flow into 'configurable_settings.xml'.
-///
-/// At least with the version of boost currently used (2016-06),
-/// native_file_string() and native_directory_string() are identical,
-/// so there is no need to differentiate between directories and
-/// filepaths.
 
 std::string native_path(std::string const& s)
 {
 #if defined LMI_MSW
-    return fs::absolute(fs::path(s)).native_file_string();
+    return fs::absolute(fs::path(s)).native_string();
 #else  // !defined LMI_MSW
     return s;
 #endif // !defined LMI_MSW

--- a/preferences_model.cpp
+++ b/preferences_model.cpp
@@ -53,7 +53,7 @@ bool is_calculation_summary_column_name(std::string const& member_name)
 std::string generic_path(std::string const& s)
 {
 #if defined LMI_MSW
-    return fs::system_complete(fs::path(s)).string();
+    return fs::absolute(fs::path(s)).string();
 #else  // !defined LMI_MSW
     return s;
 #endif // !defined LMI_MSW
@@ -80,7 +80,7 @@ std::string generic_path(std::string const& s)
 std::string native_path(std::string const& s)
 {
 #if defined LMI_MSW
-    return fs::system_complete(fs::path(s)).native_file_string();
+    return fs::absolute(fs::path(s)).native_file_string();
 #else  // !defined LMI_MSW
     return s;
 #endif // !defined LMI_MSW

--- a/preferences_model.cpp
+++ b/preferences_model.cpp
@@ -26,11 +26,9 @@
 #include "alert.hpp"
 #include "configurable_settings.hpp"
 #include "miscellany.hpp"               // begins_with()
+#include "path.hpp"
 #include "ssize_lmi.hpp"
 #include "value_cast.hpp"
-
-#include <boost/filesystem/operations.hpp> // fs::system_complete()
-#include <boost/filesystem/path.hpp>
 
 #include <sstream>
 #include <vector>

--- a/premium_tax_test.cpp
+++ b/premium_tax_test.cpp
@@ -27,7 +27,6 @@
 #include "database.hpp"
 #include "dbdict.hpp"
 #include "global_settings.hpp"
-#include "path_utility.hpp"             // initialize_filesystem()
 #include "product_data.hpp"
 #include "stratified_charges.hpp"
 #include "test_tools.hpp"
@@ -131,9 +130,6 @@ void premium_tax_test::test_rates()
 
 int test_main(int, char*[])
 {
-    // Absolute paths require "native" name-checking policy for msw.
-    initialize_filesystem();
-
     premium_tax_test::test();
 
     return EXIT_SUCCESS;

--- a/product_data.cpp
+++ b/product_data.cpp
@@ -30,10 +30,8 @@
 #include "data_directory.hpp"           // AddDataDir()
 #include "map_lookup.hpp"
 #include "my_proem.hpp"                 // ::write_proem()
+#include "path.hpp"
 #include "xml_serialize.hpp"
-
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <vector>
 

--- a/product_data.cpp
+++ b/product_data.cpp
@@ -141,7 +141,7 @@ product_data::product_data(std::string const& product_name)
 
     fs::path path(product_name);
     LMI_ASSERT(product_name == fs::basename(path));
-    path = fs::change_extension(path, ".policy");
+    path.replace_extension(".policy");
     load(AddDataDir(path.string()));
 }
 

--- a/product_data.cpp
+++ b/product_data.cpp
@@ -140,7 +140,7 @@ product_data::product_data(std::string const& product_name)
     ascribe_members();
 
     fs::path path(product_name);
-    LMI_ASSERT(product_name == fs::basename(path));
+    LMI_ASSERT(product_name == path.stem());
     path.replace_extension(".policy");
     load(AddDataDir(path.string()));
 }

--- a/product_file_test.cpp
+++ b/product_file_test.cpp
@@ -32,7 +32,6 @@
 
 #include "data_directory.hpp"           // AddDataDir()
 #include "global_settings.hpp"
-#include "path_utility.hpp"             // initialize_filesystem()
 #include "test_tools.hpp"
 #include "timer.hpp"                    // TimeAnAliquot()
 
@@ -177,9 +176,6 @@ void product_file_test::assay_speed()
 
 int test_main(int, char*[])
 {
-    // Absolute paths require "native" name-checking policy for msw.
-    initialize_filesystem();
-
     product_file_test::test();
     return EXIT_SUCCESS;
 }

--- a/rate_table.cpp
+++ b/rate_table.cpp
@@ -27,12 +27,9 @@
 #include "bourn_cast.hpp"
 #include "crc32.hpp"
 #include "miscellany.hpp"               // ios_in_binary(), ios_out_trunc_binary()
+#include "path.hpp"
 #include "path_utility.hpp"
 #include "value_cast.hpp"
-
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem/exception.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 #include <algorithm>                    // count()
 #include <climits>                      // ULLONG_MAX

--- a/rate_table.cpp
+++ b/rate_table.cpp
@@ -2338,12 +2338,12 @@ class database_impl final
   public:
     static fs::path get_index_path(fs::path const& path)
         {
-        return fs::change_extension(path, ".ndx");
+        return fs::path{path}.replace_extension(".ndx");
         }
 
     static fs::path get_data_path(fs::path const& path)
         {
-        return fs::change_extension(path, ".dat");
+        return fs::path{path}.replace_extension(".dat");
         }
 
     explicit database_impl(fs::path const& path);
@@ -2861,7 +2861,7 @@ void database_impl::save(fs::path const& path)
                 ,char     const* description
                 ,char     const* extension
                 )
-                :path_ {fs::change_extension(path, extension)}
+                :path_ {fs::path{path}.replace_extension(extension)}
                 ,temp_path_
                     {fs::exists(path_)
                         ? unique_filepath(path_, extension + std::string(".tmp"))

--- a/rate_table.cpp
+++ b/rate_table.cpp
@@ -184,19 +184,10 @@ inline bool stream_read(std::istream& is, void* data, std::size_t length)
 // there is no way to handle these errors anyhow, e.g. when we're trying to
 // clean up while handling a previous exception and so can't let another one
 // propagate.
-//
-// BOOST !! Use "ec" argument with later versions instead of throwing and
-// catching the exception.
 void remove_nothrow(fs::path const& path)
 {
-    try
-        {
-        fs::remove(path);
-        }
-    catch(fs::filesystem_error const&)
-        {
-        // Intentionally ignore.
-        }
+    std::error_code ec;
+    fs::remove(path, ec);
 }
 
 // Helper function wrapping std::strtoull() and hiding its peculiarities:

--- a/rate_table.hpp
+++ b/rate_table.hpp
@@ -23,8 +23,7 @@
 #define rate_table_hpp
 
 #include "config.hpp"
-
-#include <boost/filesystem/path.hpp>
+#include "path.hpp"
 
 #include <cstddef>                      // size_t
 #include <cstdint>

--- a/rate_table_test.cpp
+++ b/rate_table_test.cpp
@@ -25,11 +25,9 @@
 
 #include "assert_lmi.hpp"
 #include "miscellany.hpp"
+#include "path.hpp"
 #include "path_utility.hpp"
 #include "test_tools.hpp"
-
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/operations.hpp>
 
 #include <fstream>
 #include <iomanip>                      // setw(), setfill()

--- a/rate_table_tool.cpp
+++ b/rate_table_tool.cpp
@@ -143,13 +143,12 @@ void merge
         // to verify than equivalence: databases created this way from
         // the same data on different machines have identical md5sums.
         std::vector<fs::path> table_names;
-        fs::directory_iterator i(path_to_merge);
-        fs::directory_iterator const eod;
-        for(; i != eod; ++i)
+        for(auto const& i : fs::directory_iterator(path_to_merge))
             {
-            if(".rates" == fs::extension(*i))
+            auto const path{i.path()};
+            if(".rates" == path.extension())
                 {
-                table_names.push_back(*i);
+                table_names.push_back(path);
                 }
             }
         std::sort(table_names.begin(), table_names.end());

--- a/rate_table_tool.cpp
+++ b/rate_table_tool.cpp
@@ -25,11 +25,9 @@
 #include "getopt.hpp"
 #include "license.hpp"
 #include "main_common.hpp"
+#include "path.hpp"
 #include "path_utility.hpp"
 #include "rate_table.hpp"
-
-#include <boost/filesystem/convenience.hpp> // extension()
-#include <boost/filesystem/operations.hpp>  // is_directory(), directory_iterator
 
 #include <algorithm>                    // sort()
 #include <cstdio>                       // fflush()

--- a/rounding_rules.cpp
+++ b/rounding_rules.cpp
@@ -28,10 +28,8 @@
 #include "assert_lmi.hpp"
 #include "data_directory.hpp"           // AddDataDir()
 #include "my_proem.hpp"                 // ::write_proem()
+#include "path.hpp"
 #include "xml_serialize.hpp"
-
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem/path.hpp>
 
 template class xml_serializable<rounding_rules>;
 

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -65,6 +65,7 @@
 #include "miscellany.hpp"
 #include "msw_workarounds.hpp"          // PreloadDesignatedDlls()
 #include "mvc_controller.hpp"
+#include "path.hpp"
 #include "path_utility.hpp"             // fs::path inserter
 #include "policy_document.hpp"
 #include "policy_view.hpp"
@@ -81,9 +82,6 @@
 #include "verify_products.hpp"
 #include "wx_new.hpp"
 #include "wx_utility.hpp"               // class ClipboardEx
-
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <wx/artprov.h>
 #include <wx/config.h>

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -512,7 +512,7 @@ void Skeleton::UponHelp(wxCommandEvent&)
     std::string const canonical_url("https://lmi.nongnu.org/user_manual.html");
 
     std::string s(AddDataDir("user_manual.html"));
-    fs::path p(fs::system_complete(fs::path(s)));
+    fs::path p(fs::absolute(fs::path(s)));
     if(fs::exists(p))
         {
         s = "file://" + p.native_file_string();

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -515,13 +515,13 @@ void Skeleton::UponHelp(wxCommandEvent&)
     fs::path p(fs::absolute(fs::path(s)));
     if(fs::exists(p))
         {
-        s = "file://" + p.native_file_string();
+        s = "file://" + p.string();
         }
     else
         {
         warning()
             << "A local copy of the user manual should have been placed here:"
-            << "\n    " << p.native_file_string()
+            << "\n    " << p
             << "\nbut was not. Try reinstalling."
             << '\n'
             << "\nMeanwhile, the online user manual will be used if possible."
@@ -533,7 +533,7 @@ void Skeleton::UponHelp(wxCommandEvent&)
     bool r = false;
     {
     wxLogNull x;
-    r = wxLaunchDefaultBrowser(s);
+    r = wxLaunchDefaultBrowser(wxString::FromUTF8(s));
     }
     if(!r)
         {

--- a/test_coding_rules.cpp
+++ b/test_coding_rules.cpp
@@ -132,7 +132,7 @@ class file final
 file::file(std::string const& file_path)
     :path_      {file_path}
     ,full_name_ {file_path}
-    ,leaf_name_ {path_.leaf()}
+    ,leaf_name_ {path_.filename().string()}
     ,extension_ {path_.extension().string()}
     ,phylum_    {e_no_phylum}
 {

--- a/test_coding_rules.cpp
+++ b/test_coding_rules.cpp
@@ -26,12 +26,8 @@
 #include "istream_to_string.hpp"
 #include "main_common.hpp"
 #include "miscellany.hpp"               // begins_with(), split_into_lines()
+#include "path.hpp"
 #include "ssize_lmi.hpp"
-
-#include <boost/filesystem/convenience.hpp> // fs::extension()
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/operations.hpp>  // fs::exists(), fs::is_directory()
-#include <boost/filesystem/path.hpp>
 
 #include <algorithm>                    // is_sorted()
 #include <ctime>

--- a/test_coding_rules.cpp
+++ b/test_coding_rules.cpp
@@ -133,7 +133,7 @@ file::file(std::string const& file_path)
     :path_      {file_path}
     ,full_name_ {file_path}
     ,leaf_name_ {path_.leaf()}
-    ,extension_ {fs::extension(path_)}
+    ,extension_ {path_.extension().string()}
     ,phylum_    {e_no_phylum}
 {
     if(!fs::exists(path_))

--- a/view_ex.cpp
+++ b/view_ex.cpp
@@ -208,5 +208,5 @@ std::string ViewEx::base_filename() const
 {
     std::string t(GetDocument()->GetUserReadableName().ToStdString(wxConvUTF8));
     fs::path path(t);
-    return path.has_leaf() ? path.leaf() : std::string("Hastur");
+    return path.has_filename() ? path.leaf() : std::string("Hastur");
 }

--- a/view_ex.cpp
+++ b/view_ex.cpp
@@ -199,14 +199,14 @@ void ViewEx::OnDraw(wxDC*)
 ///
 /// Using wxDocument::GetUserReadableName() means the name can be
 /// altered by calling wxDocument::SetTitle(). By default, the title
-/// is the filename with no path. The call to leaf() guarantees that
+/// is the filename with no path. The call to filename() guarantees that
 /// the result is pathless, even if e.g. the title has been set to the
-/// document's full filepath. If leaf() is empty, then a name that
+/// document's full filepath. If filename() is empty, then a name that
 /// recognizably should never be uttered is returned.
 
 std::string ViewEx::base_filename() const
 {
     std::string t(GetDocument()->GetUserReadableName().ToStdString(wxConvUTF8));
     fs::path path(t);
-    return path.has_filename() ? path.leaf() : std::string("Hastur");
+    return path.has_filename() ? path.filename().string() : std::string("Hastur");
 }

--- a/view_ex.cpp
+++ b/view_ex.cpp
@@ -43,11 +43,10 @@
 #include "alert.hpp"
 #include "assert_lmi.hpp"
 #include "docmanager_ex.hpp"
+#include "path.hpp"
 #include "safely_dereference_as.hpp"
 #include "skeleton.hpp"                 // Skeleton::CreateChildFrame()
 #include "wx_new.hpp"
-
-#include <boost/filesystem/path.hpp>
 
 #include <wx/app.h>                     // GetInstance()
 #include <wx/dc.h>

--- a/wx_test_benchmark_census.cpp
+++ b/wx_test_benchmark_census.cpp
@@ -135,15 +135,15 @@ class census_benchmark
 
 LMI_WX_TEST_CASE(benchmark_census)
 {
-    fs::directory_iterator const end_i;
-    for(fs::directory_iterator i(get_test_files_path()); i != end_i; ++i)
+    for(auto const& i : fs::directory_iterator(get_test_files_path()))
         {
-        if(!wxString(i->leaf()).Matches("MSEC*.cns"))
+        auto const path{i.path()};
+        if(!wxString(path.leaf()).Matches("MSEC*.cns"))
             {
             continue;
             }
 
-        census_benchmark b(*i);
+        census_benchmark b(path);
 
         {
         // Ensure that the window doesn't stay opened (and possibly affects

--- a/wx_test_benchmark_census.cpp
+++ b/wx_test_benchmark_census.cpp
@@ -22,6 +22,7 @@
 #include "pchfile_wx.hpp"
 
 #include "assert_lmi.hpp"
+#include "path.hpp"
 #include "wx_test_case.hpp"
 #include "wx_test_statusbar.hpp"
 
@@ -30,8 +31,6 @@
 #include <wx/scopeguard.h>
 #include <wx/testing.h>
 #include <wx/uiaction.h>
-
-#include <boost/filesystem/operations.hpp>
 
 #include <cmath>                        // fabs()
 #include <iostream>

--- a/wx_test_benchmark_census.cpp
+++ b/wx_test_benchmark_census.cpp
@@ -49,7 +49,7 @@ class census_benchmark
         z.Char('o', wxMOD_CONTROL); // "File|Open"
         wxTEST_DIALOG
             (wxYield()
-            ,wxExpectModal<wxFileDialog>(path.native_file_string())
+            ,wxExpectModal<wxFileDialog>(wxString::FromUTF8(path.string()))
             );
         wxYield();
         }

--- a/wx_test_benchmark_census.cpp
+++ b/wx_test_benchmark_census.cpp
@@ -43,7 +43,7 @@ class census_benchmark
   public:
     explicit census_benchmark(fs::path const& path)
         :status_ {get_main_window_statusbar()}
-        ,name_   {path.leaf()}
+        ,name_   {wxString::FromUTF8(path.filename().string())}
         {
         wxUIActionSimulator z;
         z.Char('o', wxMOD_CONTROL); // "File|Open"
@@ -138,7 +138,7 @@ LMI_WX_TEST_CASE(benchmark_census)
     for(auto const& i : fs::directory_iterator(get_test_files_path()))
         {
         auto const path{i.path()};
-        if(!wxString(path.leaf()).Matches("MSEC*.cns"))
+        if(!wxString::FromUTF8(path.filename().string()).Matches("MSEC*.cns"))
             {
             continue;
             }

--- a/wx_test_case.hpp
+++ b/wx_test_case.hpp
@@ -23,8 +23,7 @@
 #define wx_test_case_hpp
 
 #include "config.hpp"
-
-#include <boost/filesystem/path.hpp>
+#include "path.hpp"
 
 /// Base class for the test case objects.
 ///

--- a/wx_test_config_settings.cpp
+++ b/wx_test_config_settings.cpp
@@ -23,9 +23,8 @@
 
 #include "assert_lmi.hpp"
 #include "configurable_settings.hpp"
+#include "path.hpp"
 #include "wx_test_case.hpp"
-
-#include <boost/filesystem/operations.hpp>
 
 /*
     Test configurable_settings.xml file.

--- a/wx_test_create_open.cpp
+++ b/wx_test_create_open.cpp
@@ -171,7 +171,7 @@ LMI_WX_TEST_CASE(create_open_mec)
         {
         LMI_ASSERT_WITH_MSG
             (extra_output_files[n].exists()
-            ,"file \"" << extra_output_files[n].path() << "\""
+            ,"file \"" << extra_output_files[n] << "\""
             );
         }
 }

--- a/wx_test_default_update.cpp
+++ b/wx_test_default_update.cpp
@@ -24,6 +24,7 @@
 #include "assert_lmi.hpp"
 #include "configurable_settings.hpp"
 #include "mvc_controller.hpp"
+#include "path.hpp"
 #include "wx_test_case.hpp"
 #include "wx_test_new.hpp"
 #include "wx_test_statusbar.hpp"
@@ -33,8 +34,6 @@
 #include <wx/radiobox.h>
 #include <wx/testing.h>
 #include <wx/uiaction.h>
-
-#include <boost/filesystem/operations.hpp>
 
 /// Make sure the default input file can be opened, modified, and saved.
 ///

--- a/wx_test_expiry_dates.cpp
+++ b/wx_test_expiry_dates.cpp
@@ -24,12 +24,10 @@
 #include "assert_lmi.hpp"
 #include "calendar_date.hpp"
 #include "global_settings.hpp"
+#include "path.hpp"
 #include "version.hpp"
 #include "wx_test_case.hpp"
 #include "wx_test_date.hpp"
-
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/operations.hpp>
 
 #include <iostream>
 

--- a/wx_test_output.hpp
+++ b/wx_test_output.hpp
@@ -23,8 +23,7 @@
 #define wx_test_output_hpp
 
 #include "config.hpp"
-
-#include <boost/filesystem/operations.hpp>
+#include "path.hpp"
 
 /// Class helping to check for the expected output file existence.
 ///

--- a/wx_test_output.hpp
+++ b/wx_test_output.hpp
@@ -56,11 +56,6 @@ class output_file_existence_checker
         return fs::exists(path_);
         }
 
-    std::string const& path() const
-        {
-        return path_.string();
-        }
-
     // Objects of this class can't be copied, because of side effects of its
     // dtor, but can be moved.
     output_file_existence_checker(output_file_existence_checker&&) = default;
@@ -71,6 +66,19 @@ class output_file_existence_checker
 
   private:
     fs::path path_;
+
+    friend std::ostream& operator<<(
+        std::ostream& os,
+        output_file_existence_checker const& p
+    );
 };
+
+inline std::ostream& operator<<(
+    std::ostream& os,
+    output_file_existence_checker const& p
+)
+{
+    return os << p.path_.string();
+}
 
 #endif // wx_test_output_hpp

--- a/wx_test_output_pdf.hpp
+++ b/wx_test_output_pdf.hpp
@@ -25,9 +25,8 @@
 #include "config.hpp"
 
 #include "configurable_settings.hpp"
+#include "path.hpp"
 #include "wx_test_output.hpp"
-
-#include <boost/filesystem/operations.hpp>
 
 /// Specialized version of output_file_existence_checker for the output PDF
 /// files: it takes just the base name of the file, without neither the

--- a/xml_serializable.hpp
+++ b/xml_serializable.hpp
@@ -24,10 +24,9 @@
 
 #include "config.hpp"
 
+#include "path.hpp"
 #include "so_attributes.hpp"
 #include "xml_lmi_fwd.hpp"
-
-#include <boost/filesystem/path.hpp>
 
 #include <list>
 #include <map>

--- a/xml_serializable.tpp
+++ b/xml_serializable.tpp
@@ -24,10 +24,9 @@
 #include "alert.hpp"
 #include "any_member.hpp"               // MemberSymbolTable<>
 #include "contains.hpp"
+#include "path.hpp"
 #include "platform_dependent.hpp"       // access()
 #include "xml_lmi.hpp"
-
-#include <boost/filesystem/convenience.hpp> // basename()
 
 #include <xmlwrapp/nodes_view.h>
 

--- a/xml_serializable.tpp
+++ b/xml_serializable.tpp
@@ -68,7 +68,7 @@ template<typename T>
 void xml_serializable<T>::save(fs::path const& path) const
 {
     xml_lmi::xml_document document(xml_root_name());
-    write_proem(document, fs::basename(path));
+    write_proem(document, path.stem().string());
     immit_members_into(document.root_node());
     document.save(path.string());
 }


### PR DESCRIPTION
The questions:
1. Should I split (because it also contains `fs::{i,o}fstream`) or rename (to `filesystem.hpp`) `path.hpp` ?
1. Should functions which returns or takes as a parameter `std::string` typed path be rewritten?
   ```
   std::string AddDataDir(std::string const& a_filename)
   void LMI_SO PrintRosterHeaders     (               std::string const& file_name);
   void LMI_SO PrintRosterTabDelimited(Ledger const&, std::string const& file_name);
   void global_settings::set_data_directory(std::string const& s)
   ```
1. Should I add the unit test for `fs::path` and `fs::{i,o}fstream`? Currently the separate tests are not added because the main difference is UTF8 encoding and to test it properly `c.uft-8` locale should be set, but it's not fully supported under windows. And other things like `fs::path::operator<<` are tested in `authenticity_test.cpp` and `path_utility_test.cpp`.