### PR TITLE
Remove `ln` from CI script to see the errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,9 +152,6 @@ jobs:
           </configurable_settings>
           EOF
 
-          # Create the symbolic link to pass `check_concinnity` tests.
-          ln -s $GITHUB_WORKSPACE /opt/lmi/src/lmi
-
           # Tests rely on the symlinks set up by this script, so run it.
           ./check_git_setup.sh
 


### PR DESCRIPTION
This is not meant to be applied, just for testing.