### PR TITLE
Don't use xmlwrapp bootstrap script

### DIFF
--- a/install_xml_libraries.sh
+++ b/install_xml_libraries.sh
@@ -205,7 +205,7 @@ for lib in xmlwrapp; do
     libdir="$srcdir/third_party/$lib"
     if [ ! -x "$libdir/configure" ]; then
         cd "$libdir"
-        ./bootstrap
+        autoreconf --install
     fi
     mkdir --parents "$build_dir/$lib"
     cd "$build_dir/$lib"


### PR DESCRIPTION
It is doing too much and, notably, tries to run doxygen, which is
unnecessary as we don't need to generate the library documentation at
all.

Replace the bespoke script with a general autoreconf invocation, which
is more standard, faster and doesn't output any doxygen-related errors.