### PR TITLE
Build fixes after unwind.cpp addition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
               g++-mingw-w64-i686
           else
             sudo apt-get --assume-yes install \
-              libgtk-3-dev
+              libunwind-dev libdw-dev libgtk-3-dev
           fi
 
       - name: Fix up libtool

--- a/configure.ac
+++ b/configure.ac
@@ -447,6 +447,13 @@ AC_TRY_COMPILE([#include <xmlwrapp/xmlwrapp.h>],
 CXXFLAGS=$save_CXXFLAGS
 LIBS=$save_LIBS
 
+dnl --- libunwind and libdw, only used under Linux and only with gcc/libstdc++
+if test "$USE_LINUX" = "1" -a "$CLANG" != "yes"; then
+    PKG_CHECK_MODULES(UNWIND, libunwind libdw)
+    CXXFLAGS="$CXXFLAGS $UNWIND_CFLAGS"
+    LIBS="$LIBS $UNWIND_LIBS -ldl"
+fi
+
 dnl --- CGICC (optional) ----------------
 if test "x$lmi_cgicc_option" != "xno"; then
     lmi_found_cgicc=yes

--- a/dbvalue.cpp
+++ b/dbvalue.cpp
@@ -29,7 +29,6 @@
 #include "dbnames.hpp"
 #include "et_vector.hpp"
 #include "handle_exceptions.hpp"        // report_exception()
-#include "math_functions.hpp"           // lesser_of()
 #include "print_matrix.hpp"
 #include "value_cast.hpp"
 #include "xml_serialize.hpp"
@@ -219,8 +218,8 @@ void database_entity::reshape(std::vector<int> const& new_dims)
         LMI_ASSERT(0 == z);
 
         // limit dst and source indexes to those that actually vary
-        assign(dst_idx, apply_binary(lesser_of<int>(), working_idx, dst_max_idx));
-        assign(src_idx, apply_binary(lesser_of<int>(), working_idx, src_max_idx));
+        assign(dst_idx, Min(working_idx, dst_max_idx));
+        assign(src_idx, Min(working_idx, src_max_idx));
         new_object[dst_idx] = operator[](src_idx);
         }
 

--- a/expression_template_0_test.cpp
+++ b/expression_template_0_test.cpp
@@ -76,15 +76,6 @@
 
 namespace
 {
-template<typename T>
-struct greater_of
-{
-    T operator()(T const& x, T const& y) const
-        {
-        return std::max(x, y);
-        }
-};
-
     // Global variables for timing tests. They could alternatively be
     // passed as arguments, e.g., by using std::bind, but that would
     // increase complexity in return for no real benefit.
@@ -362,7 +353,7 @@ void mete_pete_typical()
 
 // This works. It's commented out only for comparability to other
 // approaches.
-//    assign(pv0, apply_binary(greater_of<double>(), pv8, pv9));
+//    assign(pv0, Max(pv8, pv9));
 
         assign(pv9, (1.0 - pv8) * pv9);
         }

--- a/i7702.cpp
+++ b/i7702.cpp
@@ -75,11 +75,7 @@ i7702::i7702
             database_.query_into(DB_GuarRegLoanSpread, guar_loan_spread);
             assign
                 (guar_int
-                ,apply_binary
-                    (greater_of<double>()
-                    ,guar_int
-                    ,gross_loan_rate - guar_loan_spread
-                    )
+                ,Max(guar_int, gross_loan_rate - guar_loan_spread)
                 );
             }
         }
@@ -93,7 +89,7 @@ i7702::i7702
         (gross_
         ,apply_unary
             (i_upper_12_over_12_from_i<double>()
-            ,apply_binary(greater_of<double>(), statutory7702i, guar_int)
+            ,Max(statutory7702i, guar_int)
             )
         );
 
@@ -102,7 +98,7 @@ i7702::i7702
         (net_glp_
         ,apply_unary
             (i_upper_12_over_12_from_i<double>()
-            ,apply_binary(greater_of<double>(), statutory7702i, guar_int) - spread_
+            ,Max(statutory7702i, guar_int) - spread_
             )
         );
 
@@ -111,7 +107,7 @@ i7702::i7702
         (net_gsp_
         ,apply_unary
             (i_upper_12_over_12_from_i<double>()
-            ,apply_binary(greater_of<double>(), 0.02 + statutory7702i, guar_int) - spread_
+            ,Max(0.02 + statutory7702i, guar_int) - spread_
             )
         );
 

--- a/ihs_mortal.cpp
+++ b/ihs_mortal.cpp
@@ -254,9 +254,8 @@ void MortalityRates::MakeCoiRateSubstandard(std::vector<double>& coi_rates)
         {0.0, 0.25, 0.50, 0.75, 1.00, 1.25, 1.50, 2.00, 2.50, 3.00, 4.00,};
     assign
         (coi_rates
-        ,apply_binary
-            (lesser_of<double>()
-            ,MaxMonthlyCoiRate_
+        ,Min
+            (MaxMonthlyCoiRate_
             ,   AnnualFlatExtra_ / 12000.0
               + coi_rates * (1.0 + SubstdTblMult_ * factors[SubstandardTable_])
             )

--- a/math_functions.hpp
+++ b/math_functions.hpp
@@ -57,30 +57,6 @@ std::vector<T>& back_sum(std::vector<T>& v)
 // std::binary_function would have provided, because they're still
 // required for std::binder1st() or std::binder2nd(), or for PETE.
 
-template<typename T>
-struct greater_of
-{
-    using first_argument_type  = T;
-    using second_argument_type = T;
-    using result_type          = T;
-    T operator()(T const& x, T const& y) const
-        {
-        return std::max(x, y);
-        }
-};
-
-template<typename T>
-struct lesser_of
-{
-    using first_argument_type  = T;
-    using second_argument_type = T;
-    using result_type          = T;
-    T operator()(T const& x, T const& y) const
-        {
-        return std::min(x, y);
-        }
-};
-
 /// Arithmetic mean.
 ///
 /// Calculate mean as

--- a/math_functions_test.cpp
+++ b/math_functions_test.cpp
@@ -260,9 +260,6 @@ int test_main(int, char*[])
     long double smallnumL = std::numeric_limits<long double>::min();
     long double bignumL   = std::numeric_limits<long double>::max();
 
-    BOOST_TEST_EQUAL(2.0, greater_of<double>()(1.0, 2.0));
-    BOOST_TEST_EQUAL(1.0, lesser_of <double>()(1.0, 2.0));
-
     // Test mean<>().
 
     BOOST_TEST_EQUAL(1.5, mean<double>()(1.0, 2.0));

--- a/tools/pete-2.1.1/PETE/OperatorTags.h
+++ b/tools/pete-2.1.1/PETE/OperatorTags.h
@@ -435,6 +435,28 @@ struct FnArcTan2
   }
 };
 
+struct FnMax
+{
+  PETE_EMPTY_CONSTRUCTORS(FnMax)
+  template<class T1, class T2>
+  inline typename BinaryReturn<T1, T2, FnMax >::Type_t
+  operator()(const T1 &a, const T2 &b) const
+  {
+    return ((a < b) ? b : a);
+  }
+};
+
+struct FnMin
+{
+  PETE_EMPTY_CONSTRUCTORS(FnMin)
+  template<class T1, class T2>
+  inline typename BinaryReturn<T1, T2, FnMin >::Type_t
+  operator()(const T1 &a, const T2 &b) const
+  {
+    return ((a < b) ? a : b);
+  }
+};
+
 struct OpLT
 {
   PETE_EMPTY_CONSTRUCTORS(OpLT)

--- a/tools/pete-2.1.1/PETE/Tools/PeteOps.cpp
+++ b/tools/pete-2.1.1/PETE/Tools/PeteOps.cpp
@@ -193,6 +193,16 @@ void peteOps(map<string,vector<OperatorDescriptor> > &m)
                                  "atan2",
                                  "return (atan2(a,b));",
                                  ""));
+  m["binaryOps"].push_back(
+              OperatorDescriptor("FnMax",
+                                 "Max",
+                                 "return ((a < b) ? b : a);",
+                                 ""));
+  m["binaryOps"].push_back(
+              OperatorDescriptor("FnMin",
+                                 "Min",
+                                 "return ((a < b) ? a : b);",
+                                 ""));
   m["binaryStdOps"].push_back(
               OperatorDescriptor("ApplyBinary",
                                  "apply_binary",

--- a/tools/pete-2.1.1/PETE/Tools/PeteOps.in
+++ b/tools/pete-2.1.1/PETE/Tools/PeteOps.in
@@ -147,6 +147,14 @@ binaryOps
   TAG = "FnArcTan2"
   FUNCTION = "atan2"
   EXPR = "return (atan2(a,b));"
+-----
+  TAG = "FnMax"
+  FUNCTION = "Max"
+  EXPR = "return ((a < b) ? b : a);"
+-----
+  TAG = "FnMin"
+  FUNCTION = "Min"
+  EXPR = "return ((a < b) ? a : b);"
 
 binaryBoolOps
 -----

--- a/tools/pete-2.1.1/et_vector_operators.hpp
+++ b/tools/pete-2.1.1/et_vector_operators.hpp
@@ -436,6 +436,34 @@ atan2(const std::vector<T1> & l,const std::vector<T2> & r)
 }
 
 template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMax,
+  typename CreateLeaf<std::vector<T1> >::Leaf_t,
+  typename CreateLeaf<std::vector<T2> >::Leaf_t> >::Expression_t
+Max(const std::vector<T1> & l,const std::vector<T2> & r)
+{
+  typedef BinaryNode<FnMax,
+    typename CreateLeaf<std::vector<T1> >::Leaf_t,
+    typename CreateLeaf<std::vector<T2> >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<std::vector<T1> >::make(l),
+    CreateLeaf<std::vector<T2> >::make(r)));
+}
+
+template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMin,
+  typename CreateLeaf<std::vector<T1> >::Leaf_t,
+  typename CreateLeaf<std::vector<T2> >::Leaf_t> >::Expression_t
+Min(const std::vector<T1> & l,const std::vector<T2> & r)
+{
+  typedef BinaryNode<FnMin,
+    typename CreateLeaf<std::vector<T1> >::Leaf_t,
+    typename CreateLeaf<std::vector<T2> >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<std::vector<T1> >::make(l),
+    CreateLeaf<std::vector<T2> >::make(r)));
+}
+
+template<class T1,class T2>
 inline typename MakeReturn<BinaryNode<OpLT,
   typename CreateLeaf<std::vector<T1> >::Leaf_t,
   typename CreateLeaf<std::vector<T2> >::Leaf_t> >::Expression_t
@@ -722,6 +750,34 @@ inline typename MakeReturn<BinaryNode<FnArcTan2,
 atan2(const std::vector<T1> & l,const Expression<T2> & r)
 {
   typedef BinaryNode<FnArcTan2,
+    typename CreateLeaf<std::vector<T1> >::Leaf_t,
+    typename CreateLeaf<Expression<T2> >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<std::vector<T1> >::make(l),
+    CreateLeaf<Expression<T2> >::make(r)));
+}
+
+template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMax,
+  typename CreateLeaf<std::vector<T1> >::Leaf_t,
+  typename CreateLeaf<Expression<T2> >::Leaf_t> >::Expression_t
+Max(const std::vector<T1> & l,const Expression<T2> & r)
+{
+  typedef BinaryNode<FnMax,
+    typename CreateLeaf<std::vector<T1> >::Leaf_t,
+    typename CreateLeaf<Expression<T2> >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<std::vector<T1> >::make(l),
+    CreateLeaf<Expression<T2> >::make(r)));
+}
+
+template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMin,
+  typename CreateLeaf<std::vector<T1> >::Leaf_t,
+  typename CreateLeaf<Expression<T2> >::Leaf_t> >::Expression_t
+Min(const std::vector<T1> & l,const Expression<T2> & r)
+{
+  typedef BinaryNode<FnMin,
     typename CreateLeaf<std::vector<T1> >::Leaf_t,
     typename CreateLeaf<Expression<T2> >::Leaf_t> Tree_t;
   return MakeReturn<Tree_t>::make(Tree_t(
@@ -1024,6 +1080,34 @@ atan2(const Expression<T1> & l,const std::vector<T2> & r)
 }
 
 template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMax,
+  typename CreateLeaf<Expression<T1> >::Leaf_t,
+  typename CreateLeaf<std::vector<T2> >::Leaf_t> >::Expression_t
+Max(const Expression<T1> & l,const std::vector<T2> & r)
+{
+  typedef BinaryNode<FnMax,
+    typename CreateLeaf<Expression<T1> >::Leaf_t,
+    typename CreateLeaf<std::vector<T2> >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<Expression<T1> >::make(l),
+    CreateLeaf<std::vector<T2> >::make(r)));
+}
+
+template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMin,
+  typename CreateLeaf<Expression<T1> >::Leaf_t,
+  typename CreateLeaf<std::vector<T2> >::Leaf_t> >::Expression_t
+Min(const Expression<T1> & l,const std::vector<T2> & r)
+{
+  typedef BinaryNode<FnMin,
+    typename CreateLeaf<Expression<T1> >::Leaf_t,
+    typename CreateLeaf<std::vector<T2> >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<Expression<T1> >::make(l),
+    CreateLeaf<std::vector<T2> >::make(r)));
+}
+
+template<class T1,class T2>
 inline typename MakeReturn<BinaryNode<OpLT,
   typename CreateLeaf<Expression<T1> >::Leaf_t,
   typename CreateLeaf<std::vector<T2> >::Leaf_t> >::Expression_t
@@ -1318,6 +1402,34 @@ atan2(const std::vector<T1> & l,const T2 & r)
 }
 
 template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMax,
+  typename CreateLeaf<std::vector<T1> >::Leaf_t,
+  typename CreateLeaf<T2 >::Leaf_t> >::Expression_t
+Max(const std::vector<T1> & l,const T2 & r)
+{
+  typedef BinaryNode<FnMax,
+    typename CreateLeaf<std::vector<T1> >::Leaf_t,
+    typename CreateLeaf<T2 >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<std::vector<T1> >::make(l),
+    CreateLeaf<T2 >::make(r)));
+}
+
+template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMin,
+  typename CreateLeaf<std::vector<T1> >::Leaf_t,
+  typename CreateLeaf<T2 >::Leaf_t> >::Expression_t
+Min(const std::vector<T1> & l,const T2 & r)
+{
+  typedef BinaryNode<FnMin,
+    typename CreateLeaf<std::vector<T1> >::Leaf_t,
+    typename CreateLeaf<T2 >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<std::vector<T1> >::make(l),
+    CreateLeaf<T2 >::make(r)));
+}
+
+template<class T1,class T2>
 inline typename MakeReturn<BinaryNode<OpLT,
   typename CreateLeaf<std::vector<T1> >::Leaf_t,
   typename CreateLeaf<T2 >::Leaf_t> >::Expression_t
@@ -1604,6 +1716,34 @@ inline typename MakeReturn<BinaryNode<FnArcTan2,
 atan2(const T1 & l,const std::vector<T2> & r)
 {
   typedef BinaryNode<FnArcTan2,
+    typename CreateLeaf<T1 >::Leaf_t,
+    typename CreateLeaf<std::vector<T2> >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<T1 >::make(l),
+    CreateLeaf<std::vector<T2> >::make(r)));
+}
+
+template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMax,
+  typename CreateLeaf<T1 >::Leaf_t,
+  typename CreateLeaf<std::vector<T2> >::Leaf_t> >::Expression_t
+Max(const T1 & l,const std::vector<T2> & r)
+{
+  typedef BinaryNode<FnMax,
+    typename CreateLeaf<T1 >::Leaf_t,
+    typename CreateLeaf<std::vector<T2> >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<T1 >::make(l),
+    CreateLeaf<std::vector<T2> >::make(r)));
+}
+
+template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMin,
+  typename CreateLeaf<T1 >::Leaf_t,
+  typename CreateLeaf<std::vector<T2> >::Leaf_t> >::Expression_t
+Min(const T1 & l,const std::vector<T2> & r)
+{
+  typedef BinaryNode<FnMin,
     typename CreateLeaf<T1 >::Leaf_t,
     typename CreateLeaf<std::vector<T2> >::Leaf_t> Tree_t;
   return MakeReturn<Tree_t>::make(Tree_t(
@@ -2180,6 +2320,34 @@ atan2(const Expression<T1> & l,const Expression<T2> & r)
 }
 
 template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMax,
+  typename CreateLeaf<Expression<T1> >::Leaf_t,
+  typename CreateLeaf<Expression<T2> >::Leaf_t> >::Expression_t
+Max(const Expression<T1> & l,const Expression<T2> & r)
+{
+  typedef BinaryNode<FnMax,
+    typename CreateLeaf<Expression<T1> >::Leaf_t,
+    typename CreateLeaf<Expression<T2> >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<Expression<T1> >::make(l),
+    CreateLeaf<Expression<T2> >::make(r)));
+}
+
+template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMin,
+  typename CreateLeaf<Expression<T1> >::Leaf_t,
+  typename CreateLeaf<Expression<T2> >::Leaf_t> >::Expression_t
+Min(const Expression<T1> & l,const Expression<T2> & r)
+{
+  typedef BinaryNode<FnMin,
+    typename CreateLeaf<Expression<T1> >::Leaf_t,
+    typename CreateLeaf<Expression<T2> >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<Expression<T1> >::make(l),
+    CreateLeaf<Expression<T2> >::make(r)));
+}
+
+template<class T1,class T2>
 inline typename MakeReturn<BinaryNode<OpLT,
   typename CreateLeaf<Expression<T1> >::Leaf_t,
   typename CreateLeaf<Expression<T2> >::Leaf_t> >::Expression_t
@@ -2474,6 +2642,34 @@ atan2(const Expression<T1> & l,const T2 & r)
 }
 
 template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMax,
+  typename CreateLeaf<Expression<T1> >::Leaf_t,
+  typename CreateLeaf<T2 >::Leaf_t> >::Expression_t
+Max(const Expression<T1> & l,const T2 & r)
+{
+  typedef BinaryNode<FnMax,
+    typename CreateLeaf<Expression<T1> >::Leaf_t,
+    typename CreateLeaf<T2 >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<Expression<T1> >::make(l),
+    CreateLeaf<T2 >::make(r)));
+}
+
+template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMin,
+  typename CreateLeaf<Expression<T1> >::Leaf_t,
+  typename CreateLeaf<T2 >::Leaf_t> >::Expression_t
+Min(const Expression<T1> & l,const T2 & r)
+{
+  typedef BinaryNode<FnMin,
+    typename CreateLeaf<Expression<T1> >::Leaf_t,
+    typename CreateLeaf<T2 >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<Expression<T1> >::make(l),
+    CreateLeaf<T2 >::make(r)));
+}
+
+template<class T1,class T2>
 inline typename MakeReturn<BinaryNode<OpLT,
   typename CreateLeaf<Expression<T1> >::Leaf_t,
   typename CreateLeaf<T2 >::Leaf_t> >::Expression_t
@@ -2760,6 +2956,34 @@ inline typename MakeReturn<BinaryNode<FnArcTan2,
 atan2(const T1 & l,const Expression<T2> & r)
 {
   typedef BinaryNode<FnArcTan2,
+    typename CreateLeaf<T1 >::Leaf_t,
+    typename CreateLeaf<Expression<T2> >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<T1 >::make(l),
+    CreateLeaf<Expression<T2> >::make(r)));
+}
+
+template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMax,
+  typename CreateLeaf<T1 >::Leaf_t,
+  typename CreateLeaf<Expression<T2> >::Leaf_t> >::Expression_t
+Max(const T1 & l,const Expression<T2> & r)
+{
+  typedef BinaryNode<FnMax,
+    typename CreateLeaf<T1 >::Leaf_t,
+    typename CreateLeaf<Expression<T2> >::Leaf_t> Tree_t;
+  return MakeReturn<Tree_t>::make(Tree_t(
+    CreateLeaf<T1 >::make(l),
+    CreateLeaf<Expression<T2> >::make(r)));
+}
+
+template<class T1,class T2>
+inline typename MakeReturn<BinaryNode<FnMin,
+  typename CreateLeaf<T1 >::Leaf_t,
+  typename CreateLeaf<Expression<T2> >::Leaf_t> >::Expression_t
+Min(const T1 & l,const Expression<T2> & r)
+{
+  typedef BinaryNode<FnMin,
     typename CreateLeaf<T1 >::Leaf_t,
     typename CreateLeaf<Expression<T2> >::Leaf_t> Tree_t;
   return MakeReturn<Tree_t>::make(Tree_t(

--- a/tools/pete-2.1.1/et_vector_test.cpp
+++ b/tools/pete-2.1.1/et_vector_test.cpp
@@ -68,4 +68,15 @@ int main()
     assign(v0, apply_binary(std::plus<double>(), v0, 100.0));
     assign(v0, apply_binary(std::plus<double>(), 10000.0, v0));
     show_vector(v0);
+
+    // Test Min() and Max().
+    std::vector<double> v2 = {1.2, 2.3, 3.4, 7.7};
+    std::vector<double> v3 = {1.9, 2.9, 3.9, 0.0};
+    std::vector<double> v4(v2.size());
+    assign(v4, Max(v2, v3));
+    show_vector(v4);
+    assign(v4, Min(v2, v3));
+    show_vector(v4);
+
+    std::cout << "Completed." << std::endl;
 }

--- a/unwind.cpp
+++ b/unwind.cpp
@@ -37,16 +37,14 @@
 #include <libunwind.h>
 #include <typeinfo>                     // type_info
 
-#if defined __GNUC__
-#   pragma GCC diagnostic push
-    // Calls to low-level C functions may as well use "0" for
-    // terseness instead of "nullptr".
-#   pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-    // Casting dlsym objects to function pointers is allowed
-    // only as a conditional extension.
-#   pragma GCC diagnostic ignored "-Wconditionally-supported"
-#   pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif // defined __GNUC__
+#pragma GCC diagnostic push
+// Calls to low-level C functions may as well use "0" for
+// terseness instead of "nullptr".
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+// Casting dlsym objects to function pointers is allowed
+// only as a conditional extension.
+#pragma GCC diagnostic ignored "-Wconditionally-supported"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 
 // For reference, the ABI specifies this prototype:
 // extern "C" void __cxa_throw

--- a/unwind.cpp
+++ b/unwind.cpp
@@ -23,7 +23,7 @@
 
 #include "unwind.hpp"
 
-#if defined LMI_X86_64 && defined LMI_POSIX
+#if defined LMI_X86_64 && defined LMI_POSIX && defined __GLIBCXX__
 
 #define UNW_LOCAL_ONLY
 
@@ -194,4 +194,4 @@ void __cxa_throw(void* thrown_exception, std::type_info* tinfo, void (*dest)(voi
     original_cxa_throw(thrown_exception, tinfo, dest);
 }
 
-#endif // defined LMI_X86_64 && defined LMI_POSIX
+#endif // defined LMI_X86_64 && defined LMI_POSIX && defined __GLIBCXX__

--- a/unwind.cpp
+++ b/unwind.cpp
@@ -37,7 +37,6 @@
 #include <libunwind.h>
 #include <typeinfo>                     // type_info
 
-#pragma GCC diagnostic push
 // Calls to low-level C functions may as well use "0" for
 // terseness instead of "nullptr".
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"


### PR DESCRIPTION
The first commit here is required to fix the CI builds that were broken since some time.

The second one is required to fix the autotools build even when using gcc.

The next one is required to fix the build when using clang.

The remaining two commits are not really required and could be omitted, but seemed like they could be useful.