### PR TITLE
Clang tests build fixes

### DIFF
--- a/any_member_test.cpp
+++ b/any_member_test.cpp
@@ -377,39 +377,12 @@ void any_member_test::test_any_member()
 //
 // Because the problem seems confined to borland tools, I will guess
 // that it's simply a compiler defect.
-
-    // Want to be able to unify a subobject with a pmf, e.g.
-//    s["s0"].size();
-    // no matching function for call to `any_member<S>::size()
-    std::string str("xyzzy");
-
-//    std::mem_fun(&std::string::size);
-//    str.string_size();
-
-//    str.(std::mem_fun(&std::string::size));
-
-//    std::mem_fun_t sizer;
-//    std::mem_fun_t sizer();
-//    std::const_mem_fun_t(std::string::size);
-    std::mem_fun(&std::string::size)(&str);
 }
 
 void any_member_test::supplemental_test0()
 {
     S s;
     X x;
-
-    {
-    std::cout << "Testing std::mem_fun family.\n";
-    s.x0.set_str("Test 0");
-    x.set_str("Test 0x");
-    std::mem_fun1_t<int, X, std::string> x_memfun(&X::foo);
-    X* px = &x;
-//    px->*x_memfun; // Error: it's a functor, not a pmf.
-    x_memfun(px, "example 0");
-    std::mem_fun(&X::foo)(px, "example 1");
-    std::cout << std::endl;
-    }
 
     {
     std::cout << "Testing plain pointers to member data and function.\n";

--- a/calendar_date_test.cpp
+++ b/calendar_date_test.cpp
@@ -115,7 +115,14 @@ void CalendarDateTest::TestFundamentals()
     LMI_TEST_EQUAL(gregorian_epoch(), date1);
 
     // Assign from self.
+#if defined __clang__
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wself-assign-overloaded"
+#endif // defined __clang__
     date1 = date1;
+#if defined __clang__
+#   pragma clang diagnostic pop
+#endif // defined __clang__
     LMI_TEST_EQUAL(gregorian_epoch(), date1);
 
     // Assign from jdn_t.

--- a/config.hpp
+++ b/config.hpp
@@ -108,6 +108,15 @@ namespace fs = boost::filesystem;
 //
 #include "platform_dependent.hpp"
 
+// Testing for the predefined __GNUC__ is not always the right thing
+// to do, as it is also defined by mostly gcc-compatible compilers
+// such as clang or (not currently supported) icc, so define a symbol
+// which is only defined for gcc itself, but not any others, to be
+// used where the difference between them matters.
+#if defined __GNUC__ && !defined __clang__
+#   define LMI_GCC
+#endif // defined __GNUC__ && !defined __clang__
+
 // It is impossible to compile lmi with g++ prior to version 3, though
 // old versions of gcc would be adequate for C translation units.
 

--- a/fenv_lmi_test.cpp
+++ b/fenv_lmi_test.cpp
@@ -42,7 +42,7 @@
 #include <bitset>
 #include <cfenv>
 #include <climits>                      // CHAR_BIT
-#include <math.h>                       // rint()
+#include <cmath>                        // rint()
 #include <stdexcept>
 
 std::bitset<CHAR_BIT * sizeof(std::uint32_t)> bits(std::uint32_t i)

--- a/getopt.cpp
+++ b/getopt.cpp
@@ -735,19 +735,19 @@ GetOpt::operator()()
 
   {
     int c = *nextchar++;
-#if defined __GNUC__ && !defined __clang__
+#if defined LMI_GCC
 #   pragma GCC diagnostic push
 #   pragma GCC diagnostic ignored "-Wuseless-cast"
-#endif // defined __GNUC__ && !defined __clang__
+#endif // defined LMI_GCC
     // i686-w64-mingw32-g++-7.3 flags this cast as "useless", but
     // that seems to be a defect: the first argument is const, so
     // the return value is also const. Perhaps the presence of C99's
     // 'char* strchr(char const*, int);' prototype confuses g++, but
     // it's still a defect.
     char* temp = const_cast<char*>(std::strchr(noptstring.c_str(), c));
-#if defined __GNUC__ && !defined __clang__
+#if defined LMI_GCC
 #   pragma GCC diagnostic pop
-#endif // defined __GNUC__ && !defined __clang__
+#endif // defined LMI_GCC
 
     // Increment 'optind' when we start to process its last character.
     if(*nextchar == 0)

--- a/input_test.cpp
+++ b/input_test.cpp
@@ -159,11 +159,20 @@ void input_test::test_product_database()
 
     // Test query<enumerative type> with non-enumerative entities.
 
+#if defined __clang__
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif // defined __clang__
+
     // This value corresponds to no enumerator, but C++ allows that.
     db.query_into(DB_ChildRiderMinAmt, a);
     LMI_TEST_EQUAL(25000, a);
     auto const b {db.query<oenum_alb_or_anb>(DB_ChildRiderMinAmt)};
     LMI_TEST_EQUAL(25000, b);
+
+#if defined __clang__
+#   pragma clang diagnostic pop
+#endif // defined __clang__
 
     // Redundant template argument is okay.
     db.query_into<oenum_alb_or_anb>(DB_ChildRiderMinAmt, a);

--- a/md5.cpp
+++ b/md5.cpp
@@ -88,10 +88,10 @@
 # define SWAP(n) (n)
 #endif // !defined WORDS_BIGENDIAN
 
-#if defined __GNUC__ && !defined __clang__
+#if defined LMI_GCC
 #   pragma GCC diagnostic ignored "-Wold-style-cast"
 #   pragma GCC diagnostic ignored "-Wuseless-cast"
-#endif // defined __GNUC__ && !defined __clang__
+#endif // defined LMI_GCC
 
 /* This array contains the bytes used to pad the buffer to the next
  * 64-byte boundary. (RFC 1321, 3.1: Step 1)

--- a/numeric_io_test.cpp
+++ b/numeric_io_test.cpp
@@ -227,10 +227,10 @@ int test_main(int, char*[])
     LMI_TEST_EQUAL( "Z ", numeric_io_cast<std::string>( "Z "));
     LMI_TEST_EQUAL(" Z ", numeric_io_cast<std::string>(" Z "));
 
-#if defined __GNUC__
+#if defined __GNUC__ && !defined __clang__
 #   pragma GCC diagnostic push
 #   pragma GCC diagnostic ignored "-Wuseless-cast"
-#endif // defined __GNUC__
+#endif // defined __GNUC__ && !defined __clang__
 
     test_interconvertibility(static_cast<         char>(   1), "1", __FILE__, __LINE__);
     test_interconvertibility(static_cast<         char>('\1'), "1", __FILE__, __LINE__);
@@ -288,9 +288,9 @@ int test_main(int, char*[])
     LMI_TEST_EQUAL(numeric_io_cast<long double>("3.36210314311209350626e-4932"), std::numeric_limits<long double>::min());
 #endif // !defined LMI_MSVCRT
 
-#if defined __GNUC__
+#if defined __GNUC__ && !defined __clang__
 #   pragma GCC diagnostic pop
-#endif // defined __GNUC__
+#endif // defined __GNUC__ && !defined __clang__
 
     test_interconvertibility(std::string("  as  df  "), "  as  df  ", __FILE__, __LINE__);
     // The converse

--- a/numeric_io_test.cpp
+++ b/numeric_io_test.cpp
@@ -227,10 +227,10 @@ int test_main(int, char*[])
     LMI_TEST_EQUAL( "Z ", numeric_io_cast<std::string>( "Z "));
     LMI_TEST_EQUAL(" Z ", numeric_io_cast<std::string>(" Z "));
 
-#if defined __GNUC__ && !defined __clang__
+#if defined LMI_GCC
 #   pragma GCC diagnostic push
 #   pragma GCC diagnostic ignored "-Wuseless-cast"
-#endif // defined __GNUC__ && !defined __clang__
+#endif // defined LMI_GCC
 
     test_interconvertibility(static_cast<         char>(   1), "1", __FILE__, __LINE__);
     test_interconvertibility(static_cast<         char>('\1'), "1", __FILE__, __LINE__);
@@ -288,9 +288,9 @@ int test_main(int, char*[])
     LMI_TEST_EQUAL(numeric_io_cast<long double>("3.36210314311209350626e-4932"), std::numeric_limits<long double>::min());
 #endif // !defined LMI_MSVCRT
 
-#if defined __GNUC__ && !defined __clang__
+#if defined LMI_GCC
 #   pragma GCC diagnostic pop
-#endif // defined __GNUC__ && !defined __clang__
+#endif // defined LMI_GCC
 
     test_interconvertibility(std::string("  as  df  "), "  as  df  ", __FILE__, __LINE__);
     // The converse

--- a/pchfile_wx.hpp
+++ b/pchfile_wx.hpp
@@ -34,7 +34,7 @@
 // Even if precompiled headers are not really being used, use this header to
 // disable some warnings which are enabled for the rest of lmi code but have to
 // be disabled for the code using wxWidgets as they occur in wxWidgets headers.
-#if defined __GNUC__ && !defined __clang__
+#if defined LMI_GCC
 //#   pragma GCC diagnostic ignored "-Wcast-qual"
 //#   pragma GCC diagnostic ignored "-Wdouble-promotion"
 //#   pragma GCC diagnostic ignored "-Wextra-semi"
@@ -44,7 +44,7 @@
 //#   pragma GCC diagnostic ignored "-Wsuggest-override"
 //#   pragma GCC diagnostic ignored "-Wuseless-cast"
 #   pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-#endif // defined __GNUC__ && !defined __clang__
+#endif // defined LMI_GCC
 
 #if defined LMI_COMPILER_USES_PCH && !defined LMI_IGNORE_PCH
 

--- a/rate_table_test.cpp
+++ b/rate_table_test.cpp
@@ -34,6 +34,7 @@
 #include <fstream>
 #include <iomanip>                      // setw(), setfill()
 #include <ios>
+#include <iterator>                     // next()
 #include <sstream>
 #include <stdexcept>
 #include <streambuf>
@@ -129,23 +130,23 @@ int const qx_cso_num_tables = 142;
 
 std::string const qx_ins_path("/opt/lmi/data/qx_ins");
 
-// NB: "1+" is used here just to allow formatting multiline strings in a
+// NB: std::next() is used here just to allow formatting multiline strings in a
 // natural way and strips the leading new line.
 
 /// Prefix used for the test tables.
-std::string const simple_table_header(1 + R"table(
+std::string const simple_table_header(std::next(R"table(
 Table number: 1
 Table type: Aggregate
 Minimum age: 0
 Maximum age: 1
 Number of decimal places: 5
 Table values:
-)table");
+)table"));
 
-std::string const simple_table_values(1 + R"table(
+std::string const simple_table_values(std::next(R"table(
   0  0.12345
   1  0.23456
-)table");
+)table"));
 
 /// Minimal valid SOA table in text format.
 std::string const simple_table_text(simple_table_header + simple_table_values);
@@ -154,7 +155,7 @@ std::string const simple_table_text(simple_table_header + simple_table_values);
 /// 'rate_table.cpp', both write these table values in a field of width
 /// four: two spaces between columns, plus one for the data, plus one
 /// for a nonexistent decimal point.
-std::string const integral_table(1 + R"table(
+std::string const integral_table(std::next(R"table(
 Table number: 1
 Table type: Aggregate
 Minimum age: 0
@@ -163,7 +164,7 @@ Number of decimal places: 0
 Table values:
   0   0
   1   1
-)table");
+)table"));
 } // Unnamed namespace.
 
 /// Test opening database files.

--- a/snprintf_test.cpp
+++ b/snprintf_test.cpp
@@ -43,19 +43,19 @@ int test_main(int, char*[])
     LMI_TEST_EQUAL(4, len);
 
     // All tests in this group fail with the defective msvc rtl.
-#if defined __GNUC__ && !defined __clang__
+#if defined LMI_GCC
 #   pragma GCC diagnostic push
 #   pragma GCC diagnostic ignored "-Wformat-truncation"
-#endif // defined __GNUC__ && !defined __clang__
+#endif // defined LMI_GCC
     len = std::snprintf(buf, 3, "%4d", 1234);
     LMI_TEST_EQUAL(4, len);
     // This test fails with borland C++ 5.5.1 .
     LMI_TEST_EQUAL(std::string(buf, 9), std::string("12\0zzzzzz\0", 9));
 
     len = std::snprintf(buf, 4, "%4d", 1234);
-#if defined __GNUC__ && !defined __clang__
+#if defined LMI_GCC
 #   pragma GCC diagnostic pop
-#endif // defined __GNUC__ && !defined __clang__
+#endif // defined LMI_GCC
     LMI_TEST_EQUAL(4, len);
     // This test fails with the defective msvc rtl and also
     // with borland C++ 5.5.1 .
@@ -66,18 +66,18 @@ int test_main(int, char*[])
     LMI_TEST_EQUAL(std::string(buf, 9), std::string("1234\0zzzz\0", 9));
 
     long double z = 2.718281828459045L;
-#if defined __GNUC__ && !defined __clang__
+#if defined LMI_GCC
 #   pragma GCC diagnostic push
 #   pragma GCC diagnostic ignored "-Wformat-truncation"
-#endif // defined __GNUC__ && !defined __clang__
+#endif // defined LMI_GCC
     len = std::snprintf(buf, 5, "%.5Lf", z);
     LMI_TEST_EQUAL(7, len);
     // This should truncate to 2.71, not round to 2.72 .
     LMI_TEST_EQUAL(std::string(buf, 9), std::string("2.71\0zzzz\0", 9));
     len = std::snprintf(buf, 7, "%.5Lf", z);
-#if defined __GNUC__ && !defined __clang__
+#if defined LMI_GCC
 #   pragma GCC diagnostic pop
-#endif // defined __GNUC__ && !defined __clang__
+#endif // defined LMI_GCC
     LMI_TEST_EQUAL(7, len);
     LMI_TEST_EQUAL(std::string(buf, 9), std::string("2.7182\0zz\0", 9));
     len = std::snprintf(buf,       0, "%1.12Lf", z);

--- a/snprintf_test.cpp
+++ b/snprintf_test.cpp
@@ -43,19 +43,19 @@ int test_main(int, char*[])
     LMI_TEST_EQUAL(4, len);
 
     // All tests in this group fail with the defective msvc rtl.
-#if defined __GNUC__
+#if defined __GNUC__ && !defined __clang__
 #   pragma GCC diagnostic push
 #   pragma GCC diagnostic ignored "-Wformat-truncation"
-#endif // defined __GNUC__
+#endif // defined __GNUC__ && !defined __clang__
     len = std::snprintf(buf, 3, "%4d", 1234);
     LMI_TEST_EQUAL(4, len);
     // This test fails with borland C++ 5.5.1 .
     LMI_TEST_EQUAL(std::string(buf, 9), std::string("12\0zzzzzz\0", 9));
 
     len = std::snprintf(buf, 4, "%4d", 1234);
-#if defined __GNUC__
+#if defined __GNUC__ && !defined __clang__
 #   pragma GCC diagnostic pop
-#endif // defined __GNUC__
+#endif // defined __GNUC__ && !defined __clang__
     LMI_TEST_EQUAL(4, len);
     // This test fails with the defective msvc rtl and also
     // with borland C++ 5.5.1 .
@@ -66,18 +66,18 @@ int test_main(int, char*[])
     LMI_TEST_EQUAL(std::string(buf, 9), std::string("1234\0zzzz\0", 9));
 
     long double z = 2.718281828459045L;
-#if defined __GNUC__
+#if defined __GNUC__ && !defined __clang__
 #   pragma GCC diagnostic push
 #   pragma GCC diagnostic ignored "-Wformat-truncation"
-#endif // defined __GNUC__
+#endif // defined __GNUC__ && !defined __clang__
     len = std::snprintf(buf, 5, "%.5Lf", z);
     LMI_TEST_EQUAL(7, len);
     // This should truncate to 2.71, not round to 2.72 .
     LMI_TEST_EQUAL(std::string(buf, 9), std::string("2.71\0zzzz\0", 9));
     len = std::snprintf(buf, 7, "%.5Lf", z);
-#if defined __GNUC__
+#if defined __GNUC__ && !defined __clang__
 #   pragma GCC diagnostic pop
-#endif // defined __GNUC__
+#endif // defined __GNUC__ && !defined __clang__
     LMI_TEST_EQUAL(7, len);
     LMI_TEST_EQUAL(std::string(buf, 9), std::string("2.7182\0zz\0", 9));
     len = std::snprintf(buf,       0, "%1.12Lf", z);

--- a/ssize_lmi_test.cpp
+++ b/ssize_lmi_test.cpp
@@ -126,6 +126,11 @@ constexpr char f0c(T(&)[n])
     return bourn_cast<char>(n);
 }
 
+#if defined __clang__
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wbraced-scalar-init"
+#endif // defined __clang__
+
 // deduce int, return char; braced-init-list
 template<typename T, int n>
 char f0d(T(&)[n])
@@ -146,6 +151,10 @@ char f0f(T(&)[n])
 {
     return {n}; // error: narrowing conversion of '128' from 'unsigned int'
 }
+
+#if defined __clang__
+#   pragma clang diagnostic pop
+#endif // defined __clang__
 
 // deduce auto, return char; braced-init-list
 // auto is deduced to int, not to std::size_t


### PR DESCRIPTION
With this PR, all tests can now be compiled with clang too (and compiling them with gcc still works as well, of course).