### PR TITLE
Allow the test suite to fully pass under Linux when using autotools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,8 @@ jobs:
           echo "xml2_sha1=$(git rev-parse HEAD:third_party/libxml2)" >> $GITHUB_ENV
           echo "xmlwrapp_sha1=$(git rev-parse HEAD:third_party/xmlwrapp)" >> $GITHUB_ENV
           echo "xslt_sha1=$(git rev-parse HEAD:third_party/libxslt)" >> $GITHUB_ENV
+          echo "wx_sha1=$(git rev-parse HEAD:third_party/wx)" >> $GITHUB_ENV
+          echo "wxpdfdoc_sha1=$(git rev-parse HEAD:third_party/wxpdfdoc)" >> $GITHUB_ENV
 
           echo "PATH=$PATH:/opt/lmi/local/${LMI_COMPILER}_${LMI_TRIPLET}/bin" >> $GITHUB_ENV
 
@@ -140,7 +142,7 @@ jobs:
             /opt/lmi/local/${{ env.LMI_COMPILER }}_${{ env.LMI_TRIPLET }}
             /opt/lmi/local/include
             /opt/lmi/local/share
-          key: build-${{ env.LMI_COMPILER }}-${{ env.gcc_version }}-${{ env.LMI_TRIPLET }}-${{ hashFiles('install_xml_libraries.sh', 'install_wx.sh', 'install_wxpdfdoc.sh') }}-${{ env.xml2_sha1 }}-${{ env.xmlwrapp_sha1 }}-${{ env.xslt_sha1 }}
+          key: build-${{ env.LMI_COMPILER }}-${{ env.gcc_version }}-${{ env.LMI_TRIPLET }}-${{ hashFiles('install_xml_libraries.sh', 'install_wx.sh', 'install_wxpdfdoc.sh') }}-${{ env.xml2_sha1 }}-${{ env.xmlwrapp_sha1 }}-${{ env.xslt_sha1 }}-${{ env.wx_sha1 }}-${{ env.wxpdfdoc_sha1 }}
 
       - name: Build XML libraries
         if: steps.cache-local.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,20 +55,20 @@ jobs:
 
       - name: Install required packages
         run: |
-          sudo apt-get --assume-yes install \
+          packages="\
             automake bc bsdmainutils bzip2 curl cvs default-jre \
             g++-multilib git jing libarchive-tools \
             libtool libxml2-utils libxslt1-dev make patch pkg-config rsync \
-            shellcheck sudo trang unzip wget xsltproc xvfb zsh
+            shellcheck sudo trang unzip wget xsltproc xvfb zsh"
 
           if ${{ matrix.mingw }}
           then
-            sudo apt-get --assume-yes install \
-              g++-mingw-w64-i686
+            packages="$packages g++-mingw-w64-i686"
           else
-            sudo apt-get --assume-yes install \
-              libunwind-dev libdw-dev libgtk-3-dev
+            packages="$packages libunwind-dev libdw-dev libgtk-3-dev"
           fi
+
+          sudo apt-get --assume-yes install $packages
 
       - name: Fix up libtool
         run: sudo sed -i'' -e 's/^int _putenv/_CRTIMP int _putenv/' /usr/share/libtool/build-aux/ltmain.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,13 @@ jobs:
           wget -qO - https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add -
           sudo add-apt-repository "deb https://dl.winehq.org/wine-builds/ubuntu $(lsb_release -cs) main"
 
-          sudo apt-get update
+          sudo apt-get -qq update
 
           # Workaround the issue with Wine.
-          sudo apt-get install libasound2-plugins:i386 libgphoto2-6:i386
-          sudo apt-get install wine-stable-i386
-          sudo apt-get install wine-stable
-          sudo apt-get install --install-recommends winehq-stable
+          sudo apt-get -qq install libasound2-plugins:i386 libgphoto2-6:i386
+          sudo apt-get -qq install wine-stable-i386
+          sudo apt-get -qq install wine-stable
+          sudo apt-get -qq install --install-recommends winehq-stable
 
       - name: Install required packages
         run: |
@@ -66,7 +66,7 @@ jobs:
             packages="$packages libunwind-dev libdw-dev libgtk-3-dev"
           fi
 
-          sudo apt-get --assume-yes install $packages
+          sudo apt-get -qq install $packages
 
       - name: Fix up libtool
         run: sudo sed -i'' -e 's/^int _putenv/_CRTIMP int _putenv/' /usr/share/libtool/build-aux/ltmain.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,12 @@ jobs:
           - name: Linux using autotools
             mingw: false
             autotools: true
+          - name: Linux with clang
+            compiler: clang
+            mingw: false
+            autotools: true
     env:
-      LMI_COMPILER: gcc
+      LMI_COMPILER: ${{ matrix.compiler || 'gcc' }}
       LMI_TRIPLET: ${{ matrix.triplet || 'x86_64-pc-linux-gnu' }}
 
     steps:
@@ -66,6 +70,10 @@ jobs:
             packages="$packages libunwind-dev libdw-dev libgtk-3-dev"
           fi
 
+          if [ "${{ matrix.compiler }}" = clang ]; then
+            packages="$packages clang libc++abi-dev libc++-dev"
+          fi
+
           sudo apt-get -qq install $packages
 
       - name: Fix up libtool
@@ -81,6 +89,12 @@ jobs:
           else
             compiler=${LMI_COMPILER}
           fi
+
+          if [ "${{ matrix.compiler }}" = clang ]; then
+            echo "CC=clang" >> $GITHUB_ENV
+            echo "CXX=clang++ -stdlib=libc++" >> $GITHUB_ENV
+          fi
+
           gcc_version=$($compiler -dumpversion|tr -d '\r')
           echo "gcc_version=$gcc_version" >> $GITHUB_ENV
 
@@ -145,7 +159,7 @@ jobs:
         run: |
           for lib in regex filesystem; do
             cd /opt/lmi/third_party/src/boost/libs/${lib}/src
-            ${LMI_COMPILER} -std=c++17 -Wno-deprecated-declarations -DBOOST_NO_AUTO_PTR -Dregister='' -fPIC -I../../.. -c *.cpp
+            ${CXX-${LMI_COMPILER}} -std=c++17 -Wno-deprecated-declarations -DBOOST_NO_AUTO_PTR -Dregister='' -fPIC -I../../.. -c *.cpp
             ar rc /opt/lmi/local/${LMI_COMPILER}_${LMI_TRIPLET}/lib/libboost_${lib}.a *.o
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,12 +192,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          if [ !${{ matrix.mingw }} ]
-          then
-            # Currently failing tests.
-            exclude_args="excluded_unit_test_targets=path_utility_test"
-          fi
-          make $coefficiency unit_tests $exclude_args
+          make $coefficiency unit_tests
 
       - name: Run GUI tests
         if: matrix.mingw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,11 @@ jobs:
 
       - name: Check concinnity
         if: matrix.autotools != true
-        run: make $coefficiency check_concinnity
+        run: |
+          # Somehow these files are executable and this triggers complaints
+          # from check_script.sh, so avoid them by fixing permissions.
+          chmod -x .git/info/exclude .git/description
+          make $coefficiency check_concinnity
 
       - name: Check physical closure
         if: matrix.autotools != true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,9 +157,17 @@ jobs:
       - name: Build Boost libraries
         if: matrix.autotools
         run: |
+          # Define flags to avoid warnings in Boost code we don't care about.
+          boost_cxxflags="-Wno-deprecated-declarations -DBOOST_NO_AUTO_PTR -Dregister="
+          if [ "${{ matrix.compiler }}" = clang ]; then
+            boost_cxxflags="${boost_cxxflags} -Wno-parentheses-equality"
+          fi
+
           for lib in regex filesystem; do
             cd /opt/lmi/third_party/src/boost/libs/${lib}/src
-            ${CXX-${LMI_COMPILER}} -std=c++17 -Wno-deprecated-declarations -DBOOST_NO_AUTO_PTR -Dregister='' -fPIC -I../../.. -c *.cpp
+            echo "Compiling $lib sources"
+            ${CXX-${LMI_COMPILER}} -std=c++17 -fPIC $(echo ${boost_cxxflags}) -I../../.. -c *.cpp
+            echo "Creating libboost_${lib}.a from" *.o
             ar rc /opt/lmi/local/${LMI_COMPILER}_${LMI_TRIPLET}/lib/libboost_${lib}.a *.o
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,15 @@ jobs:
             types.xsd \
             /opt/lmi/data
 
-          make $coefficiency -C ${lmi_build_dir} check
+          make $coefficiency -C ${lmi_build_dir} check || err=$?
+
+          if [ -n "$err" ]; then
+            echo '*** Tests failed, contents of test-suite.log follows: ***'
+            echo '-----------------------------------------------------------'
+            cat ${lmi_build_dir}/test-suite.log
+            echo '-----------------------------------------------------------'
+            exit $err
+          fi
 
       - name: Run unit tests
         if: matrix.autotools != true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
           - name: Native Linux build
             triplet: x86_64-pc-linux-gnu
             mingw: false
+          - name: Linux using autotools
+            triplet: x86_64-pc-linux-gnu
+            mingw: false
+            autotools: true
     env:
       LMI_COMPILER: gcc
       LMI_TRIPLET: ${{ matrix.triplet }}
@@ -138,10 +142,41 @@ jobs:
         if: steps.cache-local.outputs.cache-hit != 'true'
         run: ./install_wxpdfdoc.sh
 
+      - name: Build Boost libraries
+        if: matrix.autotools
+        run: |
+          for lib in regex filesystem; do
+            cd /opt/lmi/third_party/src/boost/libs/${lib}/src
+            ${LMI_COMPILER} -std=c++17 -Wno-deprecated-declarations -DBOOST_NO_AUTO_PTR -Dregister='' -fPIC -I../../.. -c *.cpp
+            ar rc /opt/lmi/local/${LMI_COMPILER}_${LMI_TRIPLET}/lib/libboost_${lib}.a *.o
+          done
+
+      - name: Configure lmi
+        if: matrix.autotools
+        run: |
+          ./autogen.sh
+          lmi_build_dir='ci-build'
+          echo "lmi_build_dir=${lmi_build_dir}" >> $GITHUB_ENV
+          mkdir ${lmi_build_dir}
+          cd ${lmi_build_dir}
+
+          # Disable optimizations just to make the build faster.
+          ../configure --disable-optimize \
+            CPPFLAGS=-I/opt/lmi/local/include \
+            LDFLAGS=-L/opt/lmi/local/${LMI_COMPILER}_${LMI_TRIPLET}/lib \
+            PKG_CONFIG_PATH=/opt/lmi/local/${LMI_COMPILER}_${LMI_TRIPLET}/lib/pkgconfig \
+            --with-boost-headers=/opt/lmi/third_party/src/boost
+
+      - name: Build lmi (autotools)
+        if: matrix.autotools
+        run: make $coefficiency -C ${lmi_build_dir}
+
       - name: Build lmi
         run: make $coefficiency --output-sync=recurse
+        if: matrix.autotools != true
 
       - name: Build lmi with SO attributes
+        if: matrix.autotools != true
         run: make $coefficiency --output-sync=recurse build_type=so_test USE_SO_ATTRIBUTES=1 all
 
       - name: Setup lmi for tests
@@ -179,20 +214,38 @@ jobs:
           printf '391daa5cbc54e118c4737446bcb84eea'           >/opt/lmi/data/passkey
 
       - name: Install
+        if: matrix.autotools != true
         run: make install
 
       - name: Check concinnity
+        if: matrix.autotools != true
         run: make $coefficiency check_concinnity
 
       - name: Check physical closure
+        if: matrix.autotools != true
         run: make $coefficiency check_physical_closure
 
       - name: Run CLI tests
+        if: matrix.autotools != true
         run: make $coefficiency cli_tests
 
-      - name: Run unit tests
+      - name: Run unit tests (autotools)
+        if: matrix.autotools
         run: |
-          make $coefficiency unit_tests
+          # These files are used by input test from this hardcoded location.
+          cp \
+            cell.xsd \
+            multiple_cell_document.xsd \
+            single_cell_document.xsd \
+            sort_cell_subelements.xsl \
+            types.xsd \
+            /opt/lmi/data
+
+          make $coefficiency -C ${lmi_build_dir} check
+
+      - name: Run unit tests
+        if: matrix.autotools != true
+        run: make $coefficiency unit_tests
 
       - name: Run GUI tests
         if: matrix.mingw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,16 @@ jobs:
             CPPFLAGS=-I/opt/lmi/local/include \
             LDFLAGS=-L/opt/lmi/local/${LMI_COMPILER}_${LMI_TRIPLET}/lib \
             PKG_CONFIG_PATH=/opt/lmi/local/${LMI_COMPILER}_${LMI_TRIPLET}/lib/pkgconfig \
-            --with-boost-headers=/opt/lmi/third_party/src/boost
+            --with-boost-headers=/opt/lmi/third_party/src/boost \
+              || err=$?
+
+          if [ -n "$err" ]; then
+            echo '*** Configuring failed, contents of config.log follows: ***'
+            echo '-----------------------------------------------------------'
+            cat config.log
+            echo '-----------------------------------------------------------'
+            exit $err
+          fi
 
       - name: Build lmi (autotools)
         if: matrix.autotools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,11 @@ jobs:
           printf '391daa5cbc54e118c4737446bcb84eea'           >/opt/lmi/data/passkey
 
       - name: Install
+        if: matrix.autotools
+        run: |
+          env -C /opt/lmi/data $(pwd)/${lmi_build_dir}/product_files
+
+      - name: Install
         if: matrix.autotools != true
         run: make install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,13 @@ jobs:
             triplet: i686-w64-mingw32
             mingw: true
           - name: Native Linux build
-            triplet: x86_64-pc-linux-gnu
             mingw: false
           - name: Linux using autotools
-            triplet: x86_64-pc-linux-gnu
             mingw: false
             autotools: true
     env:
       LMI_COMPILER: gcc
-      LMI_TRIPLET: ${{ matrix.triplet }}
+      LMI_TRIPLET: ${{ matrix.triplet || 'x86_64-pc-linux-gnu' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,15 @@ jobs:
         run: |
           env -C /opt/lmi/data $(pwd)/${lmi_build_dir}/product_files
 
+          # These files are used by input test from this hardcoded location.
+          cp \
+            cell.xsd \
+            multiple_cell_document.xsd \
+            single_cell_document.xsd \
+            sort_cell_subelements.xsl \
+            types.xsd \
+            /opt/lmi/data
+
       - name: Install
         if: matrix.autotools != true
         run: make install
@@ -272,15 +281,6 @@ jobs:
       - name: Run unit tests (autotools)
         if: matrix.autotools
         run: |
-          # These files are used by input test from this hardcoded location.
-          cp \
-            cell.xsd \
-            multiple_cell_document.xsd \
-            single_cell_document.xsd \
-            sort_cell_subelements.xsl \
-            types.xsd \
-            /opt/lmi/data
-
           make $coefficiency -C ${lmi_build_dir} check || err=$?
 
           if [ -n "$err" ]; then

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,8 @@ endif
 
 ACLOCAL_AMFLAGS = -I aclocal
 
+AM_DEFAULT_SOURCE_EXT = .cpp
+
 ##############################################################################
 # All Targets
 ##############################################################################
@@ -391,6 +393,11 @@ libmain_auxiliary_common_la_SOURCES = \
     main_common.cpp \
     main_common_non_wx.cpp \
     sigfpe.cpp
+
+# Note: apparently useless setting of target_CXXFLAGS to its default value of
+# AM_CXXFLAGS is required for its side effect, as doing this forces automake to
+# prefix the name of the object file with "target", which is necessary to avoid
+# the clash between the same files compiled as part of different targets.
 libmain_auxiliary_common_la_CXXFLAGS = $(AM_CXXFLAGS)
 
 libantediluvian_la_SOURCES = \
@@ -590,9 +597,6 @@ libtest_common_la_SOURCES = \
   unwind.cpp
 libtest_common_la_CXXFLAGS = $(AM_CXXFLAGS)
 
-account_value_test_SOURCES = \
-  account_value_test.cpp
-account_value_test_CXXFLAGS = $(AM_CXXFLAGS)
 account_value_test_LDADD = \
   libtest_common.la
 
@@ -607,22 +611,13 @@ actuarial_table_test_LDADD = \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
-alert_test_SOURCES = \
-  alert_test.cpp
-alert_test_CXXFLAGS = $(AM_CXXFLAGS)
 alert_test_LDADD = \
   libtest_common.la
 
-any_member_test_SOURCES = \
-  any_member_test.cpp
-any_member_test_CXXFLAGS = $(AM_CXXFLAGS)
 any_member_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-assert_lmi_test_SOURCES = \
-  assert_lmi_test.cpp
-assert_lmi_test_CXXFLAGS = $(AM_CXXFLAGS)
 assert_lmi_test_LDADD = \
   libtest_common.la
 
@@ -638,34 +633,19 @@ authenticity_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-bourn_cast_test_SOURCES = \
-  bourn_cast_test.cpp
-bourn_cast_test_CXXFLAGS = $(AM_CXXFLAGS)
 bourn_cast_test_LDADD = \
   libtest_common.la
 
-cache_file_reads_test_SOURCES = \
-  cache_file_reads_test.cpp
-cache_file_reads_test_CXXFLAGS = $(AM_CXXFLAGS)
 cache_file_reads_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-calendar_date_test_SOURCES = \
-  calendar_date_test.cpp
-calendar_date_test_CXXFLAGS = $(AM_CXXFLAGS)
 calendar_date_test_LDADD = \
   libtest_common.la
 
-callback_test_SOURCES = \
-  callback_test.cpp
-callback_test_CXXFLAGS = $(AM_CXXFLAGS)
 callback_test_LDADD = \
   libtest_common.la
 
-comma_punct_test_SOURCES = \
-  comma_punct_test.cpp
-comma_punct_test_CXXFLAGS = $(AM_CXXFLAGS)
 comma_punct_test_LDADD = \
   libtest_common.la
 
@@ -691,9 +671,6 @@ configurable_settings_test_LDADD = \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
-contains_test_SOURCES = \
-  contains_test.cpp
-contains_test_CXXFLAGS = $(AM_CXXFLAGS)
 contains_test_LDADD = \
   libtest_common.la
 
@@ -704,9 +681,6 @@ crc32_test_CXXFLAGS = $(AM_CXXFLAGS)
 crc32_test_LDADD = \
   libtest_common.la
 
-currency_test_SOURCES = \
-  currency_test.cpp
-currency_test_CXXFLAGS = $(AM_CXXFLAGS)
 currency_test_LDADD = \
   libtest_common.la
 
@@ -720,15 +694,9 @@ dbo_rules_test_CXXFLAGS = $(AM_CXXFLAGS)
 dbo_rules_test_LDADD = \
   libtest_common.la
 
-et_vector_test_SOURCES = \
-  et_vector_test.cpp \
-et_vector_test_CXXFLAGS = $(AM_CXXFLAGS)
 et_vector_test_LDADD = \
   libtest_common.la
 
-expression_template_0_test_SOURCES = \
-  expression_template_0_test.cpp
-expression_template_0_test_CXXFLAGS = $(AM_CXXFLAGS)
 expression_template_0_test_LDADD = \
   libtest_common.la
 
@@ -755,15 +723,9 @@ financial_test_CXXFLAGS = $(AM_CXXFLAGS)
 financial_test_LDADD = \
   libtest_common.la
 
-getopt_test_SOURCES = \
-  getopt_test.cpp
-getopt_test_CXXFLAGS = $(AM_CXXFLAGS)
 getopt_test_LDADD = \
   libtest_common.la
 
-global_settings_test_SOURCES = \
-  global_settings_test.cpp
-global_settings_test_CXXFLAGS = $(AM_CXXFLAGS)
 global_settings_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
@@ -779,9 +741,6 @@ gpt_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-handle_exceptions_test_SOURCES = \
-  handle_exceptions_test.cpp
-handle_exceptions_test_CXXFLAGS = $(AM_CXXFLAGS)
 handle_exceptions_test_LDADD = \
   libtest_common.la
 
@@ -792,9 +751,6 @@ i7702_test_CXXFLAGS = $(AM_CXXFLAGS)
 i7702_test_LDADD = \
   libtest_common.la
 
-ieee754_test_SOURCES = \
-  ieee754_test.cpp
-ieee754_test_CXXFLAGS = $(AM_CXXFLAGS)
 ieee754_test_LDADD = \
   libtest_common.la
 
@@ -876,9 +832,6 @@ irc7702a_test_LDADD = \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
-istream_to_string_test_SOURCES = \
-  istream_to_string_test.cpp
-istream_to_string_test_CXXFLAGS = $(AM_CXXFLAGS)
 istream_to_string_test_LDADD = \
   libtest_common.la
 
@@ -911,21 +864,12 @@ loads_test_CXXFLAGS = $(AM_CXXFLAGS)
 loads_test_LDADD = \
   libtest_common.la
 
-map_lookup_test_SOURCES = \
-  map_lookup_test.cpp
-map_lookup_test_CXXFLAGS = $(AM_CXXFLAGS)
 map_lookup_test_LDADD = \
   libtest_common.la
 
-materially_equal_test_SOURCES = \
-  materially_equal_test.cpp
-materially_equal_test_CXXFLAGS = $(AM_CXXFLAGS)
 materially_equal_test_LDADD = \
   libtest_common.la
 
-math_functions_test_SOURCES = \
-  math_functions_test.cpp
-math_functions_test_CXXFLAGS = $(AM_CXXFLAGS)
 math_functions_test_LDADD = \
   libtest_common.la
 
@@ -949,15 +893,9 @@ md5sum_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-miscellany_test_SOURCES = \
-  miscellany_test.cpp
-miscellany_test_CXXFLAGS = $(AM_CXXFLAGS)
 miscellany_test_LDADD = \
   libtest_common.la
 
-monnaie_test_SOURCES = \
-  monnaie_test.cpp
-monnaie_test_CXXFLAGS = $(AM_CXXFLAGS)
 monnaie_test_LDADD = \
   libtest_common.la
 
@@ -976,22 +914,13 @@ name_value_pairs_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-ncnnnpnn_test_SOURCES = \
-  ncnnnpnn_test.cpp
-ncnnnpnn_test_CXXFLAGS = $(AM_CXXFLAGS)
 ncnnnpnn_test_LDADD = \
   libtest_common.la
 
-numeric_io_test_SOURCES = \
-  numeric_io_test.cpp
-numeric_io_test_CXXFLAGS = $(AM_CXXFLAGS)
 numeric_io_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-path_utility_test_SOURCES = \
-  path_utility_test.cpp
-path_utility_test_CXXFLAGS = $(AM_CXXFLAGS)
 path_utility_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
@@ -1071,9 +1000,6 @@ rate_table_test_LDADD = \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
-regex_test_SOURCES = \
-  regex_test.cpp
-regex_test_CXXFLAGS = $(AM_CXXFLAGS)
 regex_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
@@ -1092,15 +1018,9 @@ round_test_CXXFLAGS = $(AM_CXXFLAGS)
 round_test_LDADD = \
   libtest_common.la
 
-round_to_test_SOURCES = \
-  round_to_test.cpp
-round_to_test_CXXFLAGS = $(AM_CXXFLAGS)
 round_to_test_LDADD = \
   libtest_common.la
 
-rtti_lmi_test_SOURCES = \
-  rtti_lmi_test.cpp
-rtti_lmi_test_CXXFLAGS = $(AM_CXXFLAGS)
 rtti_lmi_test_LDADD = \
   libtest_common.la
 
@@ -1110,21 +1030,12 @@ safely_dereference_as_test_CXXFLAGS = $(AM_CXXFLAGS)
 safely_dereference_as_test_LDADD = \
   libtest_common.la
 
-sandbox_test_SOURCES = \
-  sandbox_test.cpp
-sandbox_test_CXXFLAGS = $(AM_CXXFLAGS)
 sandbox_test_LDADD = \
   libtest_common.la
 
-snprintf_test_SOURCES = \
-  snprintf_test.cpp
-snprintf_test_CXXFLAGS = $(AM_CXXFLAGS)
 snprintf_test_LDADD =\
   libtest_common.la
 
-ssize_lmi_test_SOURCES = \
-  ssize_lmi_test.cpp
-ssize_lmi_test_CXXFLAGS = $(AM_CXXFLAGS)
 ssize_lmi_test_LDADD = \
   libtest_common.la
 
@@ -1134,9 +1045,6 @@ stratified_algorithms_test_CXXFLAGS = $(AM_CXXFLAGS)
 stratified_algorithms_test_LDADD = \
   libtest_common.la
 
-stream_cast_test_SOURCES = \
-  stream_cast_test.cpp
-stream_cast_test_CXXFLAGS = $(AM_CXXFLAGS)
 stream_cast_test_LDADD = \
   libtest_common.la
 
@@ -1148,15 +1056,9 @@ system_command_test_CXXFLAGS = $(AM_CXXFLAGS)
 system_command_test_LDADD = \
   libtest_common.la
 
-test_tools_test_SOURCES = \
-  test_tools_test.cpp
-test_tools_test_CXXFLAGS = $(AM_CXXFLAGS)
 test_tools_test_LDADD = \
   libtest_common.la
 
-timer_test_SOURCES = \
-  timer_test.cpp
-timer_test_CXXFLAGS = $(AM_CXXFLAGS)
 timer_test_LDADD = \
   libtest_common.la
 
@@ -1169,22 +1071,13 @@ tn_range_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-value_cast_test_SOURCES = \
-  value_cast_test.cpp
-value_cast_test_CXXFLAGS = $(AM_CXXFLAGS)
 value_cast_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-vector_test_SOURCES = \
-  vector_test.cpp
-vector_test_CXXFLAGS = $(AM_CXXFLAGS)
 vector_test_LDADD = \
   libtest_common.la
 
-wx_new_test_SOURCES = \
-  wx_new_test.cpp
-wx_new_test_CXXFLAGS = $(AM_CXXFLAGS)
 wx_new_test_LDADD = \
   libtest_common.la
 
@@ -1197,9 +1090,6 @@ xml_serialize_test_LDADD = \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
-zero_test_SOURCES = \
-  zero_test.cpp
-zero_test_CXXFLAGS = $(AM_CXXFLAGS)
 zero_test_LDADD = \
   libtest_common.la
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -72,7 +72,8 @@ lib_LTLIBRARIES = \
 noinst_LTLIBRARIES = \
     libantediluvian.la \
     libwx_new.la \
-    libmain_auxiliary_common.la
+    libmain_auxiliary_common.la \
+    libtest_common.la
 
 # data files
 xrcdir = $(pkgdatadir)
@@ -573,263 +574,240 @@ test_coding_rules_LDADD = \
   $(BOOST_LIBS)
 
 # unit tests
-common_test_objects = \
-    alert.cpp \
-    alert_cli.cpp \
-    fenv_lmi.cpp \
-    getopt.cpp \
-    license.cpp \
-    unwind.cpp
+libtest_common_la_SOURCES = \
+  alert.cpp \
+  alert_cli.cpp \
+  calendar_date.cpp \
+  facets.cpp \
+  fenv_lmi.cpp \
+  global_settings.cpp \
+  getopt.cpp \
+  license.cpp \
+  miscellany.cpp \
+  null_stream.cpp \
+  path_utility.cpp \
+  timer.cpp \
+  unwind.cpp
+libtest_common_la_CXXFLAGS = $(AM_CXXFLAGS)
 
 test_account_value_SOURCES = \
-  $(common_test_objects) \
   account_value_test.cpp
 test_account_value_CXXFLAGS = $(AM_CXXFLAGS)
+test_account_value_LDADD = \
+  libtest_common.la
 
 test_actuarial_table_SOURCES = \
-  $(common_test_objects) \
   actuarial_table.cpp \
   actuarial_table_test.cpp \
   cso_table.cpp \
-  timer.cpp \
   xml_lmi.cpp
 test_actuarial_table_CXXFLAGS = $(AM_CXXFLAGS)
 test_actuarial_table_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
 test_alert_SOURCES = \
-  $(common_test_objects) \
   alert_test.cpp
 test_alert_CXXFLAGS = $(AM_CXXFLAGS)
+test_alert_LDADD = \
+  libtest_common.la
 
 test_any_member_SOURCES = \
-  $(common_test_objects) \
-  any_member_test.cpp \
-  calendar_date.cpp \
-  facets.cpp \
-  global_settings.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp
+  any_member_test.cpp
 test_any_member_CXXFLAGS = $(AM_CXXFLAGS)
 test_any_member_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_assert_lmi_SOURCES = \
-  $(common_test_objects) \
   assert_lmi_test.cpp
 test_assert_lmi_CXXFLAGS = $(AM_CXXFLAGS)
+test_assert_lmi_LDADD = \
+  libtest_common.la
 
-# MD5 !! Remove "timer.cpp" below.
 test_authenticity_SOURCES = \
-  $(common_test_objects) \
   authenticity.cpp \
   authenticity_test.cpp \
-  calendar_date.cpp \
-  global_settings.cpp \
   md5.cpp \
   md5sum.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp \
   system_command.cpp \
-  system_command_non_wx.cpp \
-  timer.cpp
+  system_command_non_wx.cpp
 test_authenticity_CXXFLAGS = $(AM_CXXFLAGS)
 test_authenticity_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_bourn_cast_SOURCES = \
-  $(common_test_objects) \
-  bourn_cast_test.cpp \
-  timer.cpp
+  bourn_cast_test.cpp
 test_bourn_cast_CXXFLAGS = $(AM_CXXFLAGS)
+test_bourn_cast_LDADD = \
+  libtest_common.la
 
 test_cache_file_reads_SOURCES = \
-  $(common_test_objects) \
-  cache_file_reads_test.cpp \
-  timer.cpp
+  cache_file_reads_test.cpp
 test_cache_file_reads_CXXFLAGS = $(AM_CXXFLAGS)
 test_cache_file_reads_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_calendar_date_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
-  calendar_date_test.cpp \
-  null_stream.cpp \
-  timer.cpp
+  calendar_date_test.cpp
 test_calendar_date_CXXFLAGS = $(AM_CXXFLAGS)
+test_calendar_date_LDADD = \
+  libtest_common.la
 
 test_callback_SOURCES = \
-  $(common_test_objects) \
   callback_test.cpp
 test_callback_CXXFLAGS = $(AM_CXXFLAGS)
+test_callback_LDADD = \
+  libtest_common.la
 
 test_comma_punct_SOURCES = \
-  $(common_test_objects) \
   comma_punct_test.cpp
 test_comma_punct_CXXFLAGS = $(AM_CXXFLAGS)
+test_comma_punct_LDADD = \
+  libtest_common.la
 
 test_commutation_functions_SOURCES = \
-  $(common_test_objects) \
   commutation_functions.cpp \
   commutation_functions_test.cpp \
-  cso_table.cpp \
-  timer.cpp
+  cso_table.cpp
 test_commutation_functions_CXXFLAGS = $(AM_CXXFLAGS)
+test_commutation_functions_LDADD = \
+  libtest_common.la
 
 test_configurable_settings_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
   configurable_settings.cpp \
   configurable_settings_test.cpp \
   data_directory.cpp \
   datum_base.cpp \
-  facets.cpp \
-  global_settings.cpp \
   mc_enum.cpp \
   mc_enum_types.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp \
   xml_lmi.cpp
 test_configurable_settings_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
 test_configurable_settings_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
 test_contains_SOURCES = \
-  $(common_test_objects) \
   contains_test.cpp
 test_contains_CXXFLAGS = $(AM_CXXFLAGS)
+test_contains_LDADD = \
+  libtest_common.la
 
 test_crc32_SOURCES = \
-  $(common_test_objects) \
   crc32.cpp \
   crc32_test.cpp
 test_crc32_CXXFLAGS = $(AM_CXXFLAGS)
+test_crc32_LDADD = \
+  libtest_common.la
 
 test_currency_SOURCES = \
-  $(common_test_objects) \
-  currency_test.cpp \
-  timer.cpp
+  currency_test.cpp
 test_currency_CXXFLAGS = $(AM_CXXFLAGS)
+test_currency_LDADD = \
+  libtest_common.la
 
 test_dbo_rules_SOURCES = \
-  $(common_test_objects) \
   datum_base.cpp \
   dbo_rules.cpp \
   dbo_rules_test.cpp \
-  facets.cpp \
   mc_enum.cpp \
-  mc_enum_types.cpp \
-  timer.cpp
+  mc_enum_types.cpp
 test_dbo_rules_CXXFLAGS = $(AM_CXXFLAGS)
+test_dbo_rules_LDADD = \
+  libtest_common.la
 
 test_et_vector_SOURCES = \
-  $(common_test_objects) \
-  et_vector_test.cpp \
-  timer.cpp
+  et_vector_test.cpp
 test_et_vector_CXXFLAGS = $(AM_CXXFLAGS)
+test_et_vector_LDADD = \
+  libtest_common.la
 
 test_expression_template_0_SOURCES = \
-  $(common_test_objects) \
-  expression_template_0_test.cpp \
-  timer.cpp
+  expression_template_0_test.cpp
 test_expression_template_0_CXXFLAGS = $(AM_CXXFLAGS)
+test_expression_template_0_LDADD = \
+  libtest_common.la
 
 test_fenv_lmi_SOURCES = \
-  $(common_test_objects) \
   fenv_guard.cpp \
   fenv_lmi_test.cpp
 test_fenv_lmi_CXXFLAGS = $(AM_CXXFLAGS)
+test_fenv_lmi_LDADD = \
+  libtest_common.la
 
 test_file_command_SOURCES = \
-  $(common_test_objects) \
   file_command.cpp \
   file_command_cli.cpp \
   file_command_test.cpp
 test_file_command_CXXFLAGS = $(AM_CXXFLAGS)
+test_file_command_LDADD = \
+  libtest_common.la
 
 test_financial_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
   financial.cpp \
   financial_test.cpp \
-  null_stream.cpp \
-  stratified_algorithms.cpp \
-  timer.cpp
+  stratified_algorithms.cpp
 test_financial_CXXFLAGS = $(AM_CXXFLAGS)
+test_financial_LDADD = \
+  libtest_common.la
 
 test_getopt_SOURCES = \
-  $(common_test_objects) \
   getopt_test.cpp
 test_getopt_CXXFLAGS = $(AM_CXXFLAGS)
+test_getopt_LDADD = \
+  libtest_common.la
 
 test_global_settings_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
-  global_settings.cpp \
-  global_settings_test.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp
+  global_settings_test.cpp
 test_global_settings_CXXFLAGS = $(AM_CXXFLAGS)
 test_global_settings_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_gpt_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
   commutation_functions.cpp \
   cso_table.cpp \
-  global_settings.cpp \
   gpt_commutation_functions.cpp \
   gpt_test.cpp \
-  ihs_irc7702.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp \
-  timer.cpp
+  ihs_irc7702.cpp
 test_gpt_CXXFLAGS = $(AM_CXXFLAGS)
 test_gpt_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_handle_exceptions_SOURCES = \
-  $(common_test_objects) \
   handle_exceptions_test.cpp
 test_handle_exceptions_CXXFLAGS = $(AM_CXXFLAGS)
+test_handle_exceptions_LDADD = \
+  libtest_common.la
 
 test_i7702_SOURCES = \
-  $(common_test_objects) \
   i7702.cpp \
   i7702_test.cpp
 test_i7702_CXXFLAGS = $(AM_CXXFLAGS)
+test_i7702_LDADD = \
+  libtest_common.la
 
 test_ieee754_SOURCES = \
-  $(common_test_objects) \
   ieee754_test.cpp
 test_ieee754_CXXFLAGS = $(AM_CXXFLAGS)
+test_ieee754_LDADD = \
+  libtest_common.la
 
 test_input_seq_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
-  global_settings.cpp \
   input_sequence.cpp \
   input_sequence_parser.cpp \
-  input_sequence_test.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp
+  input_sequence_test.cpp
 test_input_seq_CXXFLAGS = $(AM_CXXFLAGS)
 test_input_seq_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_input_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
   ce_product_name.cpp \
   configurable_settings.cpp \
   data_directory.cpp \
@@ -841,8 +819,6 @@ test_input_SOURCES = \
   dbnames.cpp \
   dbo_rules.cpp \
   dbvalue.cpp \
-  facets.cpp \
-  global_settings.cpp \
   input.cpp \
   input_harmonization.cpp \
   input_realization.cpp \
@@ -855,78 +831,62 @@ test_input_SOURCES = \
   mc_enum.cpp \
   mc_enum_types.cpp \
   mc_enum_types_aux.cpp \
-  miscellany.cpp \
   multiple_cell_document.cpp \
   mvc_model.cpp \
   my_proem.cpp \
-  null_stream.cpp \
-  path_utility.cpp \
   premium_tax.cpp \
   product_data.cpp \
   single_cell_document.cpp \
   stratified_charges.cpp \
-  timer.cpp \
   tn_range_types.cpp \
   xml_lmi.cpp \
   yare_input.cpp
 test_input_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
 test_input_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
 test_interpolate_string_SOURCES = \
-  $(common_test_objects) \
   interpolate_string.cpp \
   interpolate_string_test.cpp
 test_interpolate_string_CXXFLAGS = $(AM_CXXFLAGS)
+test_interpolate_string_LDADD = \
+  libtest_common.la
 
 test_irc7702_tables_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
   commutation_functions.cpp \
   cso_table.cpp \
-  global_settings.cpp \
   irc7702_tables.cpp \
-  irc7702_tables_test.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp
+  irc7702_tables_test.cpp
 test_irc7702_tables_CXXFLAGS = $(AM_CXXFLAGS)
 test_irc7702_tables_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_irc7702a_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
-  global_settings.cpp \
   ihs_irc7702a.cpp \
   irc7702a_test.cpp \
   mec_state.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp \
   stratified_algorithms.cpp \
   xml_lmi.cpp
 test_irc7702a_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
 test_irc7702a_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
 test_istream_to_string_SOURCES = \
-  $(common_test_objects) \
-  istream_to_string_test.cpp \
-  timer.cpp
+  istream_to_string_test.cpp
 test_istream_to_string_CXXFLAGS = $(AM_CXXFLAGS)
+test_istream_to_string_LDADD = \
+  libtest_common.la
 
 test_ledger_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
   configurable_settings.cpp \
   crc32.cpp \
   data_directory.cpp \
   datum_base.cpp \
-  facets.cpp \
-  global_settings.cpp \
   ledger.cpp \
   ledger_base.cpp \
   ledger_evaluator.cpp \
@@ -937,145 +897,117 @@ test_ledger_SOURCES = \
   mc_enum.cpp \
   mc_enum_types.cpp \
   mc_enum_types_aux.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp \
-  timer.cpp \
   xml_lmi.cpp
 test_ledger_CXXFLAGS = $(AM_CXXFLAGS)
 test_ledger_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
 test_loads_SOURCES = \
-  $(common_test_objects) \
   loads.cpp \
-  loads_test.cpp \
-  timer.cpp
+  loads_test.cpp
 test_loads_CXXFLAGS = $(AM_CXXFLAGS)
+test_loads_LDADD = \
+  libtest_common.la
 
 test_map_lookup_SOURCES = \
-  $(common_test_objects) \
   map_lookup_test.cpp
 test_map_lookup_CXXFLAGS = $(AM_CXXFLAGS)
+test_map_lookup_LDADD = \
+  libtest_common.la
 
 test_materially_equal_SOURCES = \
-  $(common_test_objects) \
   materially_equal_test.cpp
 test_materially_equal_CXXFLAGS = $(AM_CXXFLAGS)
+test_materially_equal_LDADD = \
+  libtest_common.la
 
 test_math_functions_SOURCES = \
-  $(common_test_objects) \
-  math_functions_test.cpp \
-  timer.cpp
+  math_functions_test.cpp
 test_math_functions_CXXFLAGS = $(AM_CXXFLAGS)
+test_math_functions_LDADD = \
+  libtest_common.la
 
 test_mc_enum_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
   ce_product_name.cpp \
   datum_base.cpp \
-  facets.cpp \
-  global_settings.cpp \
   mc_enum.cpp \
   mc_enum_test.cpp \
-  mc_enum_test_aux.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp
+  mc_enum_test_aux.cpp
 test_mc_enum_CXXFLAGS = $(AM_CXXFLAGS)
 test_mc_enum_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_md5sum_SOURCES = \
-  $(common_test_objects) \
   md5.cpp \
   md5sum.cpp \
   md5sum_test.cpp
 test_md5sum_CXXFLAGS = $(AM_CXXFLAGS)
 test_md5sum_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_miscellany_SOURCES = \
-  $(common_test_objects) \
-  miscellany.cpp \
   miscellany_test.cpp
 test_miscellany_CXXFLAGS = $(AM_CXXFLAGS)
+test_miscellany_LDADD = \
+  libtest_common.la
 
 test_monnaie_SOURCES = \
-  $(common_test_objects) \
-  monnaie_test.cpp \
-  timer.cpp
+  monnaie_test.cpp
 test_monnaie_CXXFLAGS = $(AM_CXXFLAGS)
+test_monnaie_LDADD = \
+  libtest_common.la
 
 test_mortality_rates_SOURCES = \
-  $(common_test_objects) \
   ihs_mortal.cpp \
   mortality_rates_test.cpp
 test_mortality_rates_CXXFLAGS = $(AM_CXXFLAGS)
+test_mortality_rates_LDADD = \
+  libtest_common.la
 
 test_name_value_pairs_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
-  global_settings.cpp \
-  miscellany.cpp \
   name_value_pairs.cpp \
-  name_value_pairs_test.cpp \
-  null_stream.cpp \
-  path_utility.cpp
+  name_value_pairs_test.cpp
 test_name_value_pairs_CXXFLAGS = $(AM_CXXFLAGS)
 test_name_value_pairs_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_ncnnnpnn_SOURCES = \
-  $(common_test_objects) \
   ncnnnpnn_test.cpp
 test_ncnnnpnn_CXXFLAGS = $(AM_CXXFLAGS)
+test_ncnnnpnn_LDADD = \
+  libtest_common.la
 
 test_numeric_io_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
-  global_settings.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  numeric_io_test.cpp \
-  path_utility.cpp \
-  timer.cpp
+  numeric_io_test.cpp
 test_numeric_io_CXXFLAGS = $(AM_CXXFLAGS)
 test_numeric_io_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_path_utility_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
-  global_settings.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp \
   path_utility_test.cpp
 test_path_utility_CXXFLAGS = $(AM_CXXFLAGS)
 test_path_utility_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_premium_tax_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
   data_directory.cpp \
   database.cpp \
   datum_base.cpp \
   dbdict.cpp \
   dbnames.cpp \
   dbvalue.cpp \
-  facets.cpp \
-  global_settings.cpp \
   lmi.cpp \
   mc_enum.cpp \
   mc_enum_types.cpp \
   mc_enum_types_aux.cpp \
-  miscellany.cpp \
   my_proem.cpp \
-  null_stream.cpp \
-  path_utility.cpp \
   premium_tax.cpp \
   premium_tax_test.cpp \
   product_data.cpp \
@@ -1083,218 +1015,193 @@ test_premium_tax_SOURCES = \
   xml_lmi.cpp
 test_premium_tax_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
 test_premium_tax_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
 test_print_matrix_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
   cso_table.cpp \
-  global_settings.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp \
   print_matrix_test.cpp
 test_print_matrix_CXXFLAGS = $(AM_CXXFLAGS)
 test_print_matrix_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_product_file_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
   data_directory.cpp \
   database.cpp \
   datum_base.cpp \
   dbdict.cpp \
   dbnames.cpp \
   dbvalue.cpp \
-  facets.cpp \
   fund_data.cpp \
-  global_settings.cpp \
   lingo.cpp \
   lmi.cpp \
   mc_enum.cpp \
   mc_enum_types.cpp \
   mc_enum_types_aux.cpp \
-  miscellany.cpp \
   my_proem.cpp \
-  null_stream.cpp \
-  path_utility.cpp \
   premium_tax.cpp \
   product_data.cpp \
   product_file_test.cpp \
   rounding_rules.cpp \
   stratified_charges.cpp \
-  timer.cpp \
   xml_lmi.cpp
 test_product_file_CXXFLAGS = $(AM_CXXFLAGS)
 test_product_file_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
 test_progress_meter_SOURCES = \
-  $(common_test_objects) \
-  null_stream.cpp \
   progress_meter.cpp \
   progress_meter_cli.cpp \
-  progress_meter_test.cpp \
-  timer.cpp
+  progress_meter_test.cpp
 test_progress_meter_CXXFLAGS = $(AM_CXXFLAGS)
+test_progress_meter_LDADD = \
+  libtest_common.la
 
 test_rate_table_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
   crc32.cpp \
-  global_settings.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp \
   rate_table.cpp \
   rate_table_test.cpp
 test_rate_table_CXXFLAGS = $(AM_CXXFLAGS)
 test_rate_table_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
 test_regex_SOURCES = \
-  $(common_test_objects) \
-  regex_test.cpp \
-  timer.cpp
+  regex_test.cpp
 test_regex_CXXFLAGS = $(AM_CXXFLAGS)
 test_regex_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_report_table_SOURCES = \
-  $(common_test_objects) \
   report_table.cpp \
   report_table_test.cpp
 test_report_table_CXXFLAGS = $(AM_CXXFLAGS)
+test_report_table_LDADD = \
+  libtest_common.la
 
 test_round_SOURCES = \
-  $(common_test_objects) \
   round_glibc.c \
   round_test.cpp
 test_round_CXXFLAGS = $(AM_CXXFLAGS)
+test_round_LDADD = \
+  libtest_common.la
 
 test_round_to_SOURCES = \
-  $(common_test_objects) \
   round_to_test.cpp
 test_round_to_CXXFLAGS = $(AM_CXXFLAGS)
+test_round_to_LDADD = \
+  libtest_common.la
 
 test_rtti_lmi_SOURCES = \
-  $(common_test_objects) \
   rtti_lmi_test.cpp
 test_rtti_lmi_CXXFLAGS = $(AM_CXXFLAGS)
+test_rtti_lmi_LDADD = \
+  libtest_common.la
 
 test_safely_dereference_as_SOURCES = \
-  $(common_test_objects) \
   safely_dereference_as_test.cpp
 test_safely_dereference_as_CXXFLAGS = $(AM_CXXFLAGS)
+test_safely_dereference_as_LDADD = \
+  libtest_common.la
 
 test_sandbox_SOURCES = \
-  $(common_test_objects) \
   sandbox_test.cpp
 test_sandbox_CXXFLAGS = $(AM_CXXFLAGS)
+test_sandbox_LDADD = \
+  libtest_common.la
 
 test_snprintf_SOURCES = \
-  $(common_test_objects) \
   snprintf_test.cpp
 test_snprintf_CXXFLAGS = $(AM_CXXFLAGS)
+test_snprintf_LDADD =\
+  libtest_common.la
 
 test_ssize_lmi_SOURCES = \
-  $(common_test_objects) \
   ssize_lmi_test.cpp
 test_ssize_lmi_CXXFLAGS = $(AM_CXXFLAGS)
+test_ssize_lmi_LDADD = \
+  libtest_common.la
 
 test_stratified_algorithms_SOURCES = \
-  $(common_test_objects) \
   stratified_algorithms_test.cpp
 test_stratified_algorithms_CXXFLAGS = $(AM_CXXFLAGS)
+test_stratified_algorithms_LDADD = \
+  libtest_common.la
 
 test_stream_cast_SOURCES = \
-  $(common_test_objects) \
-  facets.cpp \
-  stream_cast_test.cpp \
-  timer.cpp
+  stream_cast_test.cpp
 test_stream_cast_CXXFLAGS = $(AM_CXXFLAGS)
+test_stream_cast_LDADD = \
+  libtest_common.la
 
 test_system_command_SOURCES = \
-  $(common_test_objects) \
   system_command.cpp \
   system_command_non_wx.cpp \
   system_command_test.cpp
 test_system_command_CXXFLAGS = $(AM_CXXFLAGS)
+test_system_command_LDADD = \
+  libtest_common.la
 
 test_test_tools_SOURCES = \
-  $(common_test_objects) \
   test_tools_test.cpp
 test_test_tools_CXXFLAGS = $(AM_CXXFLAGS)
+test_test_tools_LDADD = \
+  libtest_common.la
 
 test_timer_SOURCES = \
-  $(common_test_objects) \
-  timer.cpp \
   timer_test.cpp
 test_timer_CXXFLAGS = $(AM_CXXFLAGS)
+test_timer_LDADD = \
+  libtest_common.la
 
 test_tn_range_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
   datum_base.cpp \
-  facets.cpp \
-  global_settings.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp \
   tn_range_test.cpp \
   tn_range_test_aux.cpp
 test_tn_range_CXXFLAGS = $(AM_CXXFLAGS)
 test_tn_range_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_value_cast_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
-  facets.cpp \
-  global_settings.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp \
   value_cast_test.cpp
 test_value_cast_CXXFLAGS = $(AM_CXXFLAGS)
 test_value_cast_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS)
 
 test_vector_SOURCES = \
-  $(common_test_objects) \
-  timer.cpp \
   vector_test.cpp
 test_vector_CXXFLAGS = $(AM_CXXFLAGS)
+test_vector_LDADD = \
+  libtest_common.la
 
 test_wx_new_SOURCES = \
-  $(common_test_objects) \
   wx_new_test.cpp
 test_wx_new_CXXFLAGS = $(AM_CXXFLAGS)
+test_wx_new_LDADD = \
+  libtest_common.la
 
 test_xml_serialize_SOURCES = \
-  $(common_test_objects) \
-  calendar_date.cpp \
-  global_settings.cpp \
-  miscellany.cpp \
-  null_stream.cpp \
-  path_utility.cpp \
-  timer.cpp \
   xml_lmi.cpp \
   xml_serialize_test.cpp
 test_xml_serialize_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
 test_xml_serialize_LDADD = \
+  libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
 test_zero_SOURCES = \
-  $(common_test_objects) \
-  null_stream.cpp \
   zero_test.cpp
 test_zero_CXXFLAGS = $(AM_CXXFLAGS)
+test_zero_LDADD = \
+  libtest_common.la
 
 # headers: we need to include them or they wouldn't appear in the distribution
 # this list should contain everything in `ls *.h *.hpp *.tpp *.xpp`

--- a/Makefile.am
+++ b/Makefile.am
@@ -169,6 +169,11 @@ TESTS = \
 
 check_PROGRAMS = $(TESTS)
 
+# Some tests (at least authenticity_test) rely on finding lmi binaries in PATH,
+# but they're only present in the build directory by the time the test runs, so
+# ensure they can be found there.
+AM_TESTS_ENVIRONMENT = PATH=.:$$PATH
+
 ##############################################################################
 # Targets definitions
 ##############################################################################

--- a/Makefile.am
+++ b/Makefile.am
@@ -91,79 +91,79 @@ endif
 
 # tests
 TESTS = \
-    test_account_value \
-    test_actuarial_table \
-    test_alert \
-    test_any_member \
-    test_assert_lmi \
-    test_authenticity \
-    test_bourn_cast \
-    test_cache_file_reads \
-    test_calendar_date \
-    test_callback \
-    test_comma_punct \
-    test_commutation_functions \
-    test_configurable_settings \
-    test_contains \
-    test_crc32 \
-    test_currency \
-    test_dbo_rules \
-    test_et_vector \
-    test_expression_template_0 \
-    test_fenv_lmi \
-    test_file_command \
-    test_financial \
-    test_getopt \
-    test_global_settings \
-    test_gpt \
-    test_handle_exceptions \
-    test_i7702 \
-    test_ieee754 \
-    test_input_seq \
-    test_input \
-    test_interpolate_string \
-    test_irc7702_tables \
-    test_irc7702a \
-    test_istream_to_string \
-    test_ledger \
-    test_loads \
-    test_map_lookup \
-    test_materially_equal \
-    test_math_functions \
-    test_mc_enum \
-    test_md5sum \
-    test_miscellany \
-    test_monnaie \
-    test_mortality_rates \
-    test_name_value_pairs \
-    test_ncnnnpnn \
-    test_numeric_io \
-    test_path_utility \
-    test_premium_tax \
-    test_print_matrix \
-    test_product_file \
-    test_progress_meter \
-    test_rate_table \
-    test_regex \
-    test_report_table \
-    test_round \
-    test_round_to \
-    test_rtti_lmi \
-    test_safely_dereference_as \
-    test_sandbox \
-    test_snprintf \
-    test_ssize_lmi \
-    test_stratified_algorithms \
-    test_stream_cast \
-    test_system_command \
-    test_test_tools \
-    test_timer \
-    test_tn_range \
-    test_value_cast \
-    test_vector \
-    test_wx_new \
-    test_xml_serialize \
-    test_zero
+    account_value_test \
+    actuarial_table_test \
+    alert_test \
+    any_member_test \
+    assert_lmi_test \
+    authenticity_test \
+    bourn_cast_test \
+    cache_file_reads_test \
+    calendar_date_test \
+    callback_test \
+    comma_punct_test \
+    commutation_functions_test \
+    configurable_settings_test \
+    contains_test \
+    crc32_test \
+    currency_test \
+    dbo_rules_test \
+    et_vector_test \
+    expression_template_0_test \
+    fenv_lmi_test \
+    file_command_test \
+    financial_test \
+    getopt_test \
+    global_settings_test \
+    gpt_test \
+    handle_exceptions_test \
+    i7702_test \
+    ieee754_test \
+    input_seq_test \
+    input_test \
+    interpolate_string_test \
+    irc7702_tables_test \
+    irc7702a_test \
+    istream_to_string_test \
+    ledger_test \
+    loads_test \
+    map_lookup_test \
+    materially_equal_test \
+    math_functions_test \
+    mc_enum_test \
+    md5sum_test \
+    miscellany_test \
+    monnaie_test \
+    mortality_rates_test \
+    name_value_pairs_test \
+    ncnnnpnn_test \
+    numeric_io_test \
+    path_utility_test \
+    premium_tax_test \
+    print_matrix_test \
+    product_file_test \
+    progress_meter_test \
+    rate_table_test \
+    regex_test \
+    report_table_test \
+    round_test \
+    round_to_test \
+    rtti_lmi_test \
+    safely_dereference_as_test \
+    sandbox_test \
+    snprintf_test \
+    ssize_lmi_test \
+    stratified_algorithms_test \
+    stream_cast_test \
+    system_command_test \
+    test_tools_test \
+    timer_test \
+    tn_range_test \
+    value_cast_test \
+    vector_test \
+    wx_new_test \
+    xml_serialize_test \
+    zero_test
 
 check_PROGRAMS = $(TESTS)
 
@@ -590,94 +590,94 @@ libtest_common_la_SOURCES = \
   unwind.cpp
 libtest_common_la_CXXFLAGS = $(AM_CXXFLAGS)
 
-test_account_value_SOURCES = \
+account_value_test_SOURCES = \
   account_value_test.cpp
-test_account_value_CXXFLAGS = $(AM_CXXFLAGS)
-test_account_value_LDADD = \
+account_value_test_CXXFLAGS = $(AM_CXXFLAGS)
+account_value_test_LDADD = \
   libtest_common.la
 
-test_actuarial_table_SOURCES = \
+actuarial_table_test_SOURCES = \
   actuarial_table.cpp \
   actuarial_table_test.cpp \
   cso_table.cpp \
   xml_lmi.cpp
-test_actuarial_table_CXXFLAGS = $(AM_CXXFLAGS)
-test_actuarial_table_LDADD = \
+actuarial_table_test_CXXFLAGS = $(AM_CXXFLAGS)
+actuarial_table_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
-test_alert_SOURCES = \
+alert_test_SOURCES = \
   alert_test.cpp
-test_alert_CXXFLAGS = $(AM_CXXFLAGS)
-test_alert_LDADD = \
+alert_test_CXXFLAGS = $(AM_CXXFLAGS)
+alert_test_LDADD = \
   libtest_common.la
 
-test_any_member_SOURCES = \
+any_member_test_SOURCES = \
   any_member_test.cpp
-test_any_member_CXXFLAGS = $(AM_CXXFLAGS)
-test_any_member_LDADD = \
+any_member_test_CXXFLAGS = $(AM_CXXFLAGS)
+any_member_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_assert_lmi_SOURCES = \
+assert_lmi_test_SOURCES = \
   assert_lmi_test.cpp
-test_assert_lmi_CXXFLAGS = $(AM_CXXFLAGS)
-test_assert_lmi_LDADD = \
+assert_lmi_test_CXXFLAGS = $(AM_CXXFLAGS)
+assert_lmi_test_LDADD = \
   libtest_common.la
 
-test_authenticity_SOURCES = \
+authenticity_test_SOURCES = \
   authenticity.cpp \
   authenticity_test.cpp \
   md5.cpp \
   md5sum.cpp \
   system_command.cpp \
   system_command_non_wx.cpp
-test_authenticity_CXXFLAGS = $(AM_CXXFLAGS)
-test_authenticity_LDADD = \
+authenticity_test_CXXFLAGS = $(AM_CXXFLAGS)
+authenticity_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_bourn_cast_SOURCES = \
+bourn_cast_test_SOURCES = \
   bourn_cast_test.cpp
-test_bourn_cast_CXXFLAGS = $(AM_CXXFLAGS)
-test_bourn_cast_LDADD = \
+bourn_cast_test_CXXFLAGS = $(AM_CXXFLAGS)
+bourn_cast_test_LDADD = \
   libtest_common.la
 
-test_cache_file_reads_SOURCES = \
+cache_file_reads_test_SOURCES = \
   cache_file_reads_test.cpp
-test_cache_file_reads_CXXFLAGS = $(AM_CXXFLAGS)
-test_cache_file_reads_LDADD = \
+cache_file_reads_test_CXXFLAGS = $(AM_CXXFLAGS)
+cache_file_reads_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_calendar_date_SOURCES = \
+calendar_date_test_SOURCES = \
   calendar_date_test.cpp
-test_calendar_date_CXXFLAGS = $(AM_CXXFLAGS)
-test_calendar_date_LDADD = \
+calendar_date_test_CXXFLAGS = $(AM_CXXFLAGS)
+calendar_date_test_LDADD = \
   libtest_common.la
 
-test_callback_SOURCES = \
+callback_test_SOURCES = \
   callback_test.cpp
-test_callback_CXXFLAGS = $(AM_CXXFLAGS)
-test_callback_LDADD = \
+callback_test_CXXFLAGS = $(AM_CXXFLAGS)
+callback_test_LDADD = \
   libtest_common.la
 
-test_comma_punct_SOURCES = \
+comma_punct_test_SOURCES = \
   comma_punct_test.cpp
-test_comma_punct_CXXFLAGS = $(AM_CXXFLAGS)
-test_comma_punct_LDADD = \
+comma_punct_test_CXXFLAGS = $(AM_CXXFLAGS)
+comma_punct_test_LDADD = \
   libtest_common.la
 
-test_commutation_functions_SOURCES = \
+commutation_functions_test_SOURCES = \
   commutation_functions.cpp \
   commutation_functions_test.cpp \
-  cso_table.cpp
-test_commutation_functions_CXXFLAGS = $(AM_CXXFLAGS)
-test_commutation_functions_LDADD = \
+  cso_table.cpp \
+commutation_functions_test_CXXFLAGS = $(AM_CXXFLAGS)
+commutation_functions_test_LDADD = \
   libtest_common.la
 
-test_configurable_settings_SOURCES = \
+configurable_settings_test_SOURCES = \
   configurable_settings.cpp \
   configurable_settings_test.cpp \
   data_directory.cpp \
@@ -685,129 +685,129 @@ test_configurable_settings_SOURCES = \
   mc_enum.cpp \
   mc_enum_types.cpp \
   xml_lmi.cpp
-test_configurable_settings_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
-test_configurable_settings_LDADD = \
+configurable_settings_test_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
+configurable_settings_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
-test_contains_SOURCES = \
+contains_test_SOURCES = \
   contains_test.cpp
-test_contains_CXXFLAGS = $(AM_CXXFLAGS)
-test_contains_LDADD = \
+contains_test_CXXFLAGS = $(AM_CXXFLAGS)
+contains_test_LDADD = \
   libtest_common.la
 
-test_crc32_SOURCES = \
+crc32_test_SOURCES = \
   crc32.cpp \
   crc32_test.cpp
-test_crc32_CXXFLAGS = $(AM_CXXFLAGS)
-test_crc32_LDADD = \
+crc32_test_CXXFLAGS = $(AM_CXXFLAGS)
+crc32_test_LDADD = \
   libtest_common.la
 
-test_currency_SOURCES = \
+currency_test_SOURCES = \
   currency_test.cpp
-test_currency_CXXFLAGS = $(AM_CXXFLAGS)
-test_currency_LDADD = \
+currency_test_CXXFLAGS = $(AM_CXXFLAGS)
+currency_test_LDADD = \
   libtest_common.la
 
-test_dbo_rules_SOURCES = \
+dbo_rules_test_SOURCES = \
   datum_base.cpp \
   dbo_rules.cpp \
   dbo_rules_test.cpp \
   mc_enum.cpp \
   mc_enum_types.cpp
-test_dbo_rules_CXXFLAGS = $(AM_CXXFLAGS)
-test_dbo_rules_LDADD = \
+dbo_rules_test_CXXFLAGS = $(AM_CXXFLAGS)
+dbo_rules_test_LDADD = \
   libtest_common.la
 
-test_et_vector_SOURCES = \
-  et_vector_test.cpp
-test_et_vector_CXXFLAGS = $(AM_CXXFLAGS)
-test_et_vector_LDADD = \
+et_vector_test_SOURCES = \
+  et_vector_test.cpp \
+et_vector_test_CXXFLAGS = $(AM_CXXFLAGS)
+et_vector_test_LDADD = \
   libtest_common.la
 
-test_expression_template_0_SOURCES = \
+expression_template_0_test_SOURCES = \
   expression_template_0_test.cpp
-test_expression_template_0_CXXFLAGS = $(AM_CXXFLAGS)
-test_expression_template_0_LDADD = \
+expression_template_0_test_CXXFLAGS = $(AM_CXXFLAGS)
+expression_template_0_test_LDADD = \
   libtest_common.la
 
-test_fenv_lmi_SOURCES = \
+fenv_lmi_test_SOURCES = \
   fenv_guard.cpp \
   fenv_lmi_test.cpp
-test_fenv_lmi_CXXFLAGS = $(AM_CXXFLAGS)
-test_fenv_lmi_LDADD = \
+fenv_lmi_test_CXXFLAGS = $(AM_CXXFLAGS)
+fenv_lmi_test_LDADD = \
   libtest_common.la
 
-test_file_command_SOURCES = \
+file_command_test_SOURCES = \
   file_command.cpp \
   file_command_cli.cpp \
   file_command_test.cpp
-test_file_command_CXXFLAGS = $(AM_CXXFLAGS)
-test_file_command_LDADD = \
+file_command_test_CXXFLAGS = $(AM_CXXFLAGS)
+file_command_test_LDADD = \
   libtest_common.la
 
-test_financial_SOURCES = \
+financial_test_SOURCES = \
   financial.cpp \
   financial_test.cpp \
   stratified_algorithms.cpp
-test_financial_CXXFLAGS = $(AM_CXXFLAGS)
-test_financial_LDADD = \
+financial_test_CXXFLAGS = $(AM_CXXFLAGS)
+financial_test_LDADD = \
   libtest_common.la
 
-test_getopt_SOURCES = \
+getopt_test_SOURCES = \
   getopt_test.cpp
-test_getopt_CXXFLAGS = $(AM_CXXFLAGS)
-test_getopt_LDADD = \
+getopt_test_CXXFLAGS = $(AM_CXXFLAGS)
+getopt_test_LDADD = \
   libtest_common.la
 
-test_global_settings_SOURCES = \
+global_settings_test_SOURCES = \
   global_settings_test.cpp
-test_global_settings_CXXFLAGS = $(AM_CXXFLAGS)
-test_global_settings_LDADD = \
+global_settings_test_CXXFLAGS = $(AM_CXXFLAGS)
+global_settings_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_gpt_SOURCES = \
+gpt_test_SOURCES = \
   commutation_functions.cpp \
   cso_table.cpp \
   gpt_commutation_functions.cpp \
   gpt_test.cpp \
   ihs_irc7702.cpp
-test_gpt_CXXFLAGS = $(AM_CXXFLAGS)
-test_gpt_LDADD = \
+gpt_test_CXXFLAGS = $(AM_CXXFLAGS)
+gpt_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_handle_exceptions_SOURCES = \
+handle_exceptions_test_SOURCES = \
   handle_exceptions_test.cpp
-test_handle_exceptions_CXXFLAGS = $(AM_CXXFLAGS)
-test_handle_exceptions_LDADD = \
+handle_exceptions_test_CXXFLAGS = $(AM_CXXFLAGS)
+handle_exceptions_test_LDADD = \
   libtest_common.la
 
-test_i7702_SOURCES = \
+i7702_test_SOURCES = \
   i7702.cpp \
   i7702_test.cpp
-test_i7702_CXXFLAGS = $(AM_CXXFLAGS)
-test_i7702_LDADD = \
+i7702_test_CXXFLAGS = $(AM_CXXFLAGS)
+i7702_test_LDADD = \
   libtest_common.la
 
-test_ieee754_SOURCES = \
+ieee754_test_SOURCES = \
   ieee754_test.cpp
-test_ieee754_CXXFLAGS = $(AM_CXXFLAGS)
-test_ieee754_LDADD = \
+ieee754_test_CXXFLAGS = $(AM_CXXFLAGS)
+ieee754_test_LDADD = \
   libtest_common.la
 
-test_input_seq_SOURCES = \
+input_seq_test_SOURCES = \
   input_sequence.cpp \
   input_sequence_parser.cpp \
   input_sequence_test.cpp
-test_input_seq_CXXFLAGS = $(AM_CXXFLAGS)
-test_input_seq_LDADD = \
+input_seq_test_CXXFLAGS = $(AM_CXXFLAGS)
+input_seq_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_input_SOURCES = \
+input_test_SOURCES = \
   ce_product_name.cpp \
   configurable_settings.cpp \
   data_directory.cpp \
@@ -841,48 +841,48 @@ test_input_SOURCES = \
   tn_range_types.cpp \
   xml_lmi.cpp \
   yare_input.cpp
-test_input_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
-test_input_LDADD = \
+input_test_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
+input_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
-test_interpolate_string_SOURCES = \
+interpolate_string_test_SOURCES = \
   interpolate_string.cpp \
   interpolate_string_test.cpp
-test_interpolate_string_CXXFLAGS = $(AM_CXXFLAGS)
-test_interpolate_string_LDADD = \
+interpolate_string_test_CXXFLAGS = $(AM_CXXFLAGS)
+interpolate_string_test_LDADD = \
   libtest_common.la
 
-test_irc7702_tables_SOURCES = \
+irc7702_tables_test_SOURCES = \
   commutation_functions.cpp \
   cso_table.cpp \
   irc7702_tables.cpp \
   irc7702_tables_test.cpp
-test_irc7702_tables_CXXFLAGS = $(AM_CXXFLAGS)
-test_irc7702_tables_LDADD = \
+irc7702_tables_test_CXXFLAGS = $(AM_CXXFLAGS)
+irc7702_tables_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_irc7702a_SOURCES = \
+irc7702a_test_SOURCES = \
   ihs_irc7702a.cpp \
   irc7702a_test.cpp \
   mec_state.cpp \
   stratified_algorithms.cpp \
   xml_lmi.cpp
-test_irc7702a_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
-test_irc7702a_LDADD = \
+irc7702a_test_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
+irc7702a_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
-test_istream_to_string_SOURCES = \
+istream_to_string_test_SOURCES = \
   istream_to_string_test.cpp
-test_istream_to_string_CXXFLAGS = $(AM_CXXFLAGS)
-test_istream_to_string_LDADD = \
+istream_to_string_test_CXXFLAGS = $(AM_CXXFLAGS)
+istream_to_string_test_LDADD = \
   libtest_common.la
 
-test_ledger_SOURCES = \
+ledger_test_SOURCES = \
   configurable_settings.cpp \
   crc32.cpp \
   data_directory.cpp \
@@ -898,105 +898,105 @@ test_ledger_SOURCES = \
   mc_enum_types.cpp \
   mc_enum_types_aux.cpp \
   xml_lmi.cpp
-test_ledger_CXXFLAGS = $(AM_CXXFLAGS)
-test_ledger_LDADD = \
+ledger_test_CXXFLAGS = $(AM_CXXFLAGS)
+ledger_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
-test_loads_SOURCES = \
+loads_test_SOURCES = \
   loads.cpp \
   loads_test.cpp
-test_loads_CXXFLAGS = $(AM_CXXFLAGS)
-test_loads_LDADD = \
+loads_test_CXXFLAGS = $(AM_CXXFLAGS)
+loads_test_LDADD = \
   libtest_common.la
 
-test_map_lookup_SOURCES = \
+map_lookup_test_SOURCES = \
   map_lookup_test.cpp
-test_map_lookup_CXXFLAGS = $(AM_CXXFLAGS)
-test_map_lookup_LDADD = \
+map_lookup_test_CXXFLAGS = $(AM_CXXFLAGS)
+map_lookup_test_LDADD = \
   libtest_common.la
 
-test_materially_equal_SOURCES = \
+materially_equal_test_SOURCES = \
   materially_equal_test.cpp
-test_materially_equal_CXXFLAGS = $(AM_CXXFLAGS)
-test_materially_equal_LDADD = \
+materially_equal_test_CXXFLAGS = $(AM_CXXFLAGS)
+materially_equal_test_LDADD = \
   libtest_common.la
 
-test_math_functions_SOURCES = \
+math_functions_test_SOURCES = \
   math_functions_test.cpp
-test_math_functions_CXXFLAGS = $(AM_CXXFLAGS)
-test_math_functions_LDADD = \
+math_functions_test_CXXFLAGS = $(AM_CXXFLAGS)
+math_functions_test_LDADD = \
   libtest_common.la
 
-test_mc_enum_SOURCES = \
+mc_enum_test_SOURCES = \
   ce_product_name.cpp \
   datum_base.cpp \
   mc_enum.cpp \
   mc_enum_test.cpp \
   mc_enum_test_aux.cpp
-test_mc_enum_CXXFLAGS = $(AM_CXXFLAGS)
-test_mc_enum_LDADD = \
+mc_enum_test_CXXFLAGS = $(AM_CXXFLAGS)
+mc_enum_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_md5sum_SOURCES = \
+md5sum_test_SOURCES = \
   md5.cpp \
   md5sum.cpp \
   md5sum_test.cpp
-test_md5sum_CXXFLAGS = $(AM_CXXFLAGS)
-test_md5sum_LDADD = \
+md5sum_test_CXXFLAGS = $(AM_CXXFLAGS)
+md5sum_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_miscellany_SOURCES = \
+miscellany_test_SOURCES = \
   miscellany_test.cpp
-test_miscellany_CXXFLAGS = $(AM_CXXFLAGS)
-test_miscellany_LDADD = \
+miscellany_test_CXXFLAGS = $(AM_CXXFLAGS)
+miscellany_test_LDADD = \
   libtest_common.la
 
-test_monnaie_SOURCES = \
+monnaie_test_SOURCES = \
   monnaie_test.cpp
-test_monnaie_CXXFLAGS = $(AM_CXXFLAGS)
-test_monnaie_LDADD = \
+monnaie_test_CXXFLAGS = $(AM_CXXFLAGS)
+monnaie_test_LDADD = \
   libtest_common.la
 
-test_mortality_rates_SOURCES = \
+mortality_rates_test_SOURCES = \
   ihs_mortal.cpp \
   mortality_rates_test.cpp
-test_mortality_rates_CXXFLAGS = $(AM_CXXFLAGS)
-test_mortality_rates_LDADD = \
+mortality_rates_test_CXXFLAGS = $(AM_CXXFLAGS)
+mortality_rates_test_LDADD = \
   libtest_common.la
 
-test_name_value_pairs_SOURCES = \
+name_value_pairs_test_SOURCES = \
   name_value_pairs.cpp \
   name_value_pairs_test.cpp
-test_name_value_pairs_CXXFLAGS = $(AM_CXXFLAGS)
-test_name_value_pairs_LDADD = \
+name_value_pairs_test_CXXFLAGS = $(AM_CXXFLAGS)
+name_value_pairs_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_ncnnnpnn_SOURCES = \
+ncnnnpnn_test_SOURCES = \
   ncnnnpnn_test.cpp
-test_ncnnnpnn_CXXFLAGS = $(AM_CXXFLAGS)
-test_ncnnnpnn_LDADD = \
+ncnnnpnn_test_CXXFLAGS = $(AM_CXXFLAGS)
+ncnnnpnn_test_LDADD = \
   libtest_common.la
 
-test_numeric_io_SOURCES = \
+numeric_io_test_SOURCES = \
   numeric_io_test.cpp
-test_numeric_io_CXXFLAGS = $(AM_CXXFLAGS)
-test_numeric_io_LDADD = \
+numeric_io_test_CXXFLAGS = $(AM_CXXFLAGS)
+numeric_io_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_path_utility_SOURCES = \
+path_utility_test_SOURCES = \
   path_utility_test.cpp
-test_path_utility_CXXFLAGS = $(AM_CXXFLAGS)
-test_path_utility_LDADD = \
+path_utility_test_CXXFLAGS = $(AM_CXXFLAGS)
+path_utility_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_premium_tax_SOURCES = \
+premium_tax_test_SOURCES = \
   data_directory.cpp \
   database.cpp \
   datum_base.cpp \
@@ -1013,21 +1013,21 @@ test_premium_tax_SOURCES = \
   product_data.cpp \
   stratified_charges.cpp \
   xml_lmi.cpp
-test_premium_tax_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
-test_premium_tax_LDADD = \
+premium_tax_test_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
+premium_tax_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
-test_print_matrix_SOURCES = \
+print_matrix_test_SOURCES = \
   cso_table.cpp \
   print_matrix_test.cpp
-test_print_matrix_CXXFLAGS = $(AM_CXXFLAGS)
-test_print_matrix_LDADD = \
+print_matrix_test_CXXFLAGS = $(AM_CXXFLAGS)
+print_matrix_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_product_file_SOURCES = \
+product_file_test_SOURCES = \
   data_directory.cpp \
   database.cpp \
   datum_base.cpp \
@@ -1047,160 +1047,160 @@ test_product_file_SOURCES = \
   rounding_rules.cpp \
   stratified_charges.cpp \
   xml_lmi.cpp
-test_product_file_CXXFLAGS = $(AM_CXXFLAGS)
-test_product_file_LDADD = \
+product_file_test_CXXFLAGS = $(AM_CXXFLAGS)
+product_file_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
-test_progress_meter_SOURCES = \
+progress_meter_test_SOURCES = \
   progress_meter.cpp \
   progress_meter_cli.cpp \
   progress_meter_test.cpp
-test_progress_meter_CXXFLAGS = $(AM_CXXFLAGS)
-test_progress_meter_LDADD = \
+progress_meter_test_CXXFLAGS = $(AM_CXXFLAGS)
+progress_meter_test_LDADD = \
   libtest_common.la
 
-test_rate_table_SOURCES = \
+rate_table_test_SOURCES = \
   crc32.cpp \
   rate_table.cpp \
   rate_table_test.cpp
-test_rate_table_CXXFLAGS = $(AM_CXXFLAGS)
-test_rate_table_LDADD = \
+rate_table_test_CXXFLAGS = $(AM_CXXFLAGS)
+rate_table_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
-test_regex_SOURCES = \
+regex_test_SOURCES = \
   regex_test.cpp
-test_regex_CXXFLAGS = $(AM_CXXFLAGS)
-test_regex_LDADD = \
+regex_test_CXXFLAGS = $(AM_CXXFLAGS)
+regex_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_report_table_SOURCES = \
+report_table_test_SOURCES = \
   report_table.cpp \
   report_table_test.cpp
-test_report_table_CXXFLAGS = $(AM_CXXFLAGS)
-test_report_table_LDADD = \
+report_table_test_CXXFLAGS = $(AM_CXXFLAGS)
+report_table_test_LDADD = \
   libtest_common.la
 
-test_round_SOURCES = \
+round_test_SOURCES = \
   round_glibc.c \
   round_test.cpp
-test_round_CXXFLAGS = $(AM_CXXFLAGS)
-test_round_LDADD = \
+round_test_CXXFLAGS = $(AM_CXXFLAGS)
+round_test_LDADD = \
   libtest_common.la
 
-test_round_to_SOURCES = \
+round_to_test_SOURCES = \
   round_to_test.cpp
-test_round_to_CXXFLAGS = $(AM_CXXFLAGS)
-test_round_to_LDADD = \
+round_to_test_CXXFLAGS = $(AM_CXXFLAGS)
+round_to_test_LDADD = \
   libtest_common.la
 
-test_rtti_lmi_SOURCES = \
+rtti_lmi_test_SOURCES = \
   rtti_lmi_test.cpp
-test_rtti_lmi_CXXFLAGS = $(AM_CXXFLAGS)
-test_rtti_lmi_LDADD = \
+rtti_lmi_test_CXXFLAGS = $(AM_CXXFLAGS)
+rtti_lmi_test_LDADD = \
   libtest_common.la
 
-test_safely_dereference_as_SOURCES = \
+safely_dereference_as_test_SOURCES = \
   safely_dereference_as_test.cpp
-test_safely_dereference_as_CXXFLAGS = $(AM_CXXFLAGS)
-test_safely_dereference_as_LDADD = \
+safely_dereference_as_test_CXXFLAGS = $(AM_CXXFLAGS)
+safely_dereference_as_test_LDADD = \
   libtest_common.la
 
-test_sandbox_SOURCES = \
+sandbox_test_SOURCES = \
   sandbox_test.cpp
-test_sandbox_CXXFLAGS = $(AM_CXXFLAGS)
-test_sandbox_LDADD = \
+sandbox_test_CXXFLAGS = $(AM_CXXFLAGS)
+sandbox_test_LDADD = \
   libtest_common.la
 
-test_snprintf_SOURCES = \
+snprintf_test_SOURCES = \
   snprintf_test.cpp
-test_snprintf_CXXFLAGS = $(AM_CXXFLAGS)
-test_snprintf_LDADD =\
+snprintf_test_CXXFLAGS = $(AM_CXXFLAGS)
+snprintf_test_LDADD =\
   libtest_common.la
 
-test_ssize_lmi_SOURCES = \
+ssize_lmi_test_SOURCES = \
   ssize_lmi_test.cpp
-test_ssize_lmi_CXXFLAGS = $(AM_CXXFLAGS)
-test_ssize_lmi_LDADD = \
+ssize_lmi_test_CXXFLAGS = $(AM_CXXFLAGS)
+ssize_lmi_test_LDADD = \
   libtest_common.la
 
-test_stratified_algorithms_SOURCES = \
+stratified_algorithms_test_SOURCES = \
   stratified_algorithms_test.cpp
-test_stratified_algorithms_CXXFLAGS = $(AM_CXXFLAGS)
-test_stratified_algorithms_LDADD = \
+stratified_algorithms_test_CXXFLAGS = $(AM_CXXFLAGS)
+stratified_algorithms_test_LDADD = \
   libtest_common.la
 
-test_stream_cast_SOURCES = \
+stream_cast_test_SOURCES = \
   stream_cast_test.cpp
-test_stream_cast_CXXFLAGS = $(AM_CXXFLAGS)
-test_stream_cast_LDADD = \
+stream_cast_test_CXXFLAGS = $(AM_CXXFLAGS)
+stream_cast_test_LDADD = \
   libtest_common.la
 
-test_system_command_SOURCES = \
+system_command_test_SOURCES = \
   system_command.cpp \
   system_command_non_wx.cpp \
   system_command_test.cpp
-test_system_command_CXXFLAGS = $(AM_CXXFLAGS)
-test_system_command_LDADD = \
+system_command_test_CXXFLAGS = $(AM_CXXFLAGS)
+system_command_test_LDADD = \
   libtest_common.la
 
-test_test_tools_SOURCES = \
+test_tools_test_SOURCES = \
   test_tools_test.cpp
-test_test_tools_CXXFLAGS = $(AM_CXXFLAGS)
-test_test_tools_LDADD = \
+test_tools_test_CXXFLAGS = $(AM_CXXFLAGS)
+test_tools_test_LDADD = \
   libtest_common.la
 
-test_timer_SOURCES = \
+timer_test_SOURCES = \
   timer_test.cpp
-test_timer_CXXFLAGS = $(AM_CXXFLAGS)
-test_timer_LDADD = \
+timer_test_CXXFLAGS = $(AM_CXXFLAGS)
+timer_test_LDADD = \
   libtest_common.la
 
-test_tn_range_SOURCES = \
+tn_range_test_SOURCES = \
   datum_base.cpp \
   tn_range_test.cpp \
   tn_range_test_aux.cpp
-test_tn_range_CXXFLAGS = $(AM_CXXFLAGS)
-test_tn_range_LDADD = \
+tn_range_test_CXXFLAGS = $(AM_CXXFLAGS)
+tn_range_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_value_cast_SOURCES = \
+value_cast_test_SOURCES = \
   value_cast_test.cpp
-test_value_cast_CXXFLAGS = $(AM_CXXFLAGS)
-test_value_cast_LDADD = \
+value_cast_test_CXXFLAGS = $(AM_CXXFLAGS)
+value_cast_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS)
 
-test_vector_SOURCES = \
+vector_test_SOURCES = \
   vector_test.cpp
-test_vector_CXXFLAGS = $(AM_CXXFLAGS)
-test_vector_LDADD = \
+vector_test_CXXFLAGS = $(AM_CXXFLAGS)
+vector_test_LDADD = \
   libtest_common.la
 
-test_wx_new_SOURCES = \
+wx_new_test_SOURCES = \
   wx_new_test.cpp
-test_wx_new_CXXFLAGS = $(AM_CXXFLAGS)
-test_wx_new_LDADD = \
+wx_new_test_CXXFLAGS = $(AM_CXXFLAGS)
+wx_new_test_LDADD = \
   libtest_common.la
 
-test_xml_serialize_SOURCES = \
+xml_serialize_test_SOURCES = \
   xml_lmi.cpp \
   xml_serialize_test.cpp
-test_xml_serialize_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
-test_xml_serialize_LDADD = \
+xml_serialize_test_CXXFLAGS = $(AM_CXXFLAGS) $(XMLWRAPP_CFLAGS)
+xml_serialize_test_LDADD = \
   libtest_common.la \
   $(BOOST_LIBS) \
   $(XMLWRAPP_LIBS)
 
-test_zero_SOURCES = \
+zero_test_SOURCES = \
   zero_test.cpp
-test_zero_CXXFLAGS = $(AM_CXXFLAGS)
-test_zero_LDADD = \
+zero_test_CXXFLAGS = $(AM_CXXFLAGS)
+zero_test_LDADD = \
   libtest_common.la
 
 # headers: we need to include them or they wouldn't appear in the distribution

--- a/alert_cli.cpp
+++ b/alert_cli.cpp
@@ -23,9 +23,13 @@
 
 #include "alert.hpp"
 
+#include "force_linking.hpp"
+
 #include <cstdio>                       // getchar()
 #include <iostream>
 #include <stdexcept>
+
+LMI_FORCE_LINKING_IN_SITU(alert_cli)
 
 namespace
 {

--- a/boost_regex.hpp
+++ b/boost_regex.hpp
@@ -34,9 +34,9 @@
 #       pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #       pragma GCC diagnostic ignored "-Wregister"
 #   endif // 7 <= __GNUC__
-#   if 10 <= __GNUC__
+#   if 9 <= __GNUC__
 #       pragma GCC diagnostic ignored "-Wdeprecated-copy"
-#   endif // 10 <= __GNUC__
+#   endif // 9 <= __GNUC__
 #   pragma GCC diagnostic ignored "-Wshadow"
 #   pragma GCC diagnostic ignored "-Wswitch-enum"
 #   pragma GCC diagnostic ignored "-Wuseless-cast"

--- a/boost_regex.hpp
+++ b/boost_regex.hpp
@@ -26,8 +26,12 @@
 
 #if defined __clang__
 #   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wchar-subscripts"
 #   pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #   pragma clang diagnostic ignored "-Wdeprecated-copy"
+#   pragma clang diagnostic ignored "-Wkeyword-macro"
+#   pragma clang diagnostic ignored "-Wparentheses-equality"
+#   pragma clang diagnostic ignored "-Wregister"
 #elif defined __GNUC__
 #   pragma GCC diagnostic push
 #   if 7 <= __GNUC__

--- a/configure.ac
+++ b/configure.ac
@@ -560,6 +560,7 @@ fi
 if test "x$GXX" == "xyes"; then
     if test "$CLANG" = "yes"; then
         cxx_warnings_flags="$cxx_warnings_flags \
+            -Wno-string-plus-int \
             -Wno-mismatched-tags"
     else
         cxx_warnings_flags="$cxx_warnings_flags \

--- a/configure.ac
+++ b/configure.ac
@@ -592,5 +592,21 @@ if test "x$GXX" == "xyes"; then
 fi
 
 dnl === Generate output files ===
+
+dnl These files are used by various tests and must be present in the build
+dnl directory. The configurable settings file contains just the bare minimum
+dnl required, but what little is there, is really needed for the tests to pass.
+AC_CONFIG_COMMANDS([configurable_settings.xml], [
+cat >configurable_settings.xml <<EOF
+<?xml version="1.0"?>
+<configurable_settings version="2">
+  <print_directory>.</print_directory>
+  <spreadsheet_file_extension>.tsv</spreadsheet_file_extension>
+</configurable_settings>
+EOF
+])
+AC_CONFIG_COMMANDS([sample.policy], [touch sample.policy])
+AC_CONFIG_LINKS([sample.cns:sample.cns sample.ill:sample.ill])
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -346,6 +346,11 @@ else
 if they are installed in non default location"
 fi
 
+dnl Disable the use of std::auto_ptr<> which is not available in C++17 (and is
+dnl actually not available, rather than still being there and just generating
+dnl deprecation warnings, in clang libc++).
+CPPFLAGS="$CPPFLAGS -DBOOST_NO_AUTO_PTR"
+
 AC_CHECK_HEADER([boost/type_traits.hpp],
     [],
     [AC_MSG_FAILURE([Boost headers not found, $errmsg])],
@@ -362,6 +367,7 @@ boost_libsystem="boost_system$lmi_boost_toolkit"
 boost_libfs="boost_filesystem$lmi_boost_toolkit"
 boost_libregex="boost_regex$lmi_boost_toolkit"
 
+save_CPPFLAGS=$CPPFLAGS
 save_LIBS=$LIBS
 save_LDFLAGS=$LDFLAGS
 if test "x$lmi_boost_libs" != "x"; then
@@ -372,6 +378,10 @@ else
     errmsg="use --with-boost-libs=dir
 if it is installed in non default location"
 fi
+
+dnl Prevent warnings due to the use of "register" in Boost.Regex headers that
+dnl are actually fatal errors with clang in C++17 mode.
+CPPFLAGS="$save_CPPFLAGS -Dregister="
 
 dnl latest versions of boost extract some common functionality in
 dnl libboost_system which we must link when using any other Boost library, so
@@ -398,6 +408,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <boost/regex.hpp>]],
 
 LDFLAGS=$save_LDFLAGS
 LIBS=$save_LIBS
+CPPFLAGS=$save_CPPFLAGS
 
 BOOST_LIBS="-l$boost_libfs -l$boost_libregex $BOOST_LIBS"
 

--- a/configure.ac
+++ b/configure.ac
@@ -150,6 +150,12 @@ if test "$lmi_cv_cxx_std17" = "no"; then
     )
 fi
 
+dnl These options must be always used for lmi unit tests to pass.
+common_options="-fno-ms-extensions -frounding-math"
+
+CFLAGS="$CFLAGS $common_options"
+CXXFLAGS="$CXXFLAGS $common_options"
+
 AC_PROG_LD
 
 # This is a workaround for the harmless but annoying warning

--- a/install_wx.sh
+++ b/install_wx.sh
@@ -55,7 +55,9 @@ case "$build_type" in
 esac
 
 # Distinguish wx dll by host type, compiler version, and wx SHA1.
-gcc_version=$(make --no-print-directory --directory="$srcdir" show_gcc_version)
+if [ -z "$gcc_version" ]; then
+    gcc_version=$(make --no-print-directory --directory="$srcdir" show_gcc_version)
+fi
 vendor=${LMI_TRIPLET}-$gcc_version-$(git rev-parse --short HEAD:third_party/wx)
 
 # Configuration reference:

--- a/install_wxpdfdoc.sh
+++ b/install_wxpdfdoc.sh
@@ -85,7 +85,9 @@ fi
 cd "$wxpdfdoc_dir"
 autoreconf --verbose
 
-gcc_version=$(make --no-print-directory --directory="$srcdir" show_gcc_version)
+if [ -z "$gcc_version" ]; then
+    gcc_version=$(make --no-print-directory --directory="$srcdir" show_gcc_version)
+fi
 build_dir="$exec_prefix/wxpdfdoc-ad_hoc/lmi-$LMI_COMPILER-$gcc_version"
 
 if [ "$wxpdfdoc_skip_clean" != 1 ]

--- a/install_xml_libraries.sh
+++ b/install_xml_libraries.sh
@@ -218,7 +218,14 @@ for lib in libxml2 libxslt; do
         LDFLAGS="$xmlsoft_common_ldflags" \
         CPPFLAGS='-w' \
         CFLAGS="-g -O2 $xmlsoft_common_cflags" \
-        $(eval "echo \$${lib}_options")
+        $(eval "echo \$${lib}_options") || err=$?
+    if [ -n "$err" ]; then
+        echo '*** Configuring failed, contents of config.log follows: ***'
+        echo '-----------------------------------------------------------'
+        cat config.log
+        echo '-----------------------------------------------------------'
+        exit $err
+    fi
     $MAKE install
 done
 
@@ -237,7 +244,14 @@ for lib in xmlwrapp; do
     # shellcheck disable=SC2086
     "$libdir/configure" \
         PKG_CONFIG_LIBDIR="$exec_prefix"/lib/pkgconfig \
-        $xmlwrapp_options
+        $xmlwrapp_options || err=$?
+    if [ -n "$err" ]; then
+        echo '*** Configuring failed, contents of config.log follows: ***'
+        echo '-----------------------------------------------------------'
+        cat config.log
+        echo '-----------------------------------------------------------'
+        exit $err
+    fi
     $MAKE install
 done
 

--- a/numeric_io_test.cpp
+++ b/numeric_io_test.cpp
@@ -29,7 +29,16 @@
 #include "test_tools.hpp"
 #include "timer.hpp"
 
+#if defined __clang__
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wsometimes-uninitialized"
+#endif // defined __clang__
+
 #include <boost/lexical_cast.hpp>
+
+#if defined __clang__
+#   pragma clang diagnostic pop
+#endif // defined __clang__
 
 #include <cmath>                        // exp()
 #include <limits>

--- a/test_main.cpp
+++ b/test_main.cpp
@@ -60,6 +60,7 @@
 
 #include "exit_codes.hpp"
 #include "fenv_lmi.hpp"
+#include "force_linking.hpp"
 #include "miscellany.hpp"               // stifle_warning_for_unused_value()
 #include "test_tools.hpp"
 
@@ -69,6 +70,8 @@
 #include <regex>
 #include <stdexcept>
 #include <string>
+
+LMI_FORCE_LINKING_EX_SITU(alert_cli)
 
 // GWC changed namespace 'boost' to prevent any conflict with code in
 // a later version of boost.


### PR DESCRIPTION
Also significantly simplify `Makefile.am` and don't recompile the same files many hundreds time.

The only non-autotools-related change here is required to ensure the CLI alert function pointers are initialized. The same technique as already used elsewhere is used here too for consistency but a possibly simpler (but IMO also uglier) alternative might be to just `#include "alert_cli.cpp"` from `test_tools.hpp` instead of compiling it separately to ensure that it's always available.

There is also a potentially better solution for the problem of the TSV extension mismatch in `ledger_test.cpp`: it might be a better idea to use `configurable_settings::spreadsheet_file_extension()` rather than hardcoding `.tsv` in the test, but I've kept the changes to the minimum.