### PR TITLE
Avoid clang 12 warnings with stifle_warning_for_unused_value()

### DIFF
--- a/miscellany.hpp
+++ b/miscellany.hpp
@@ -243,7 +243,7 @@ inline void stifle_warning_for_unused_variable(T const&)
 /// for volatile types.
 
 template<typename T>
-inline void stifle_warning_for_unused_value(T const& t)
+inline void stifle_warning_for_unused_value(T& t)
 {
     (void)&t;
 }


### PR DESCRIPTION
Pass a non-const reference to the function to avoid warnings about the
variable being passed to this function being uninitialized -- as it
happens in e.g. math_functions_test.cpp.