### PR TITLE
Run "apt update" before installing the packages in the CI script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
             packages="$packages clang libc++abi-dev libc++-dev"
           fi
 
+          sudo apt-get -q -o=Dpkg::Use-Pty=0 update
           sudo apt-get -qq install $packages
 
       - name: Fix up libtool


### PR DESCRIPTION
Without it, installing default-jre package fails as it resolves to a
package version not available from the repositories any more.