### PR TITLE
Don't check for Boost headers in configure any longer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,6 @@ jobs:
             CPPFLAGS=-I/opt/lmi/local/include \
             LDFLAGS=-L/opt/lmi/local/${LMI_COMPILER}_${LMI_TRIPLET}/lib \
             PKG_CONFIG_PATH=/opt/lmi/local/${LMI_COMPILER}_${LMI_TRIPLET}/lib/pkgconfig \
-            --with-boost-headers=/opt/lmi/third_party/src/boost \
               || err=$?
 
           if [ -n "$err" ]; then

--- a/README.auto
+++ b/README.auto
@@ -32,7 +32,7 @@ a) we can use standard "configure && make && make install" invocation and
    can be used
 
 b) configure does run-time checks which allows to find 3rd party libraries
-   (boost, wxWidgets, ...) and adapt to other systems/compilers more easily
+   (wxWidgets, xmlwrapp, ...) and adapt to other systems/compilers more easily
 
 c) makefiles are much simpler and we get install, dist and check targets
    for free

--- a/configure.ac
+++ b/configure.ac
@@ -54,10 +54,6 @@ AM_CONDITIONAL(LMI_MSW, [test "$USE_WINDOWS" = 1])
 
 dnl === Command line options ===
 
-AC_ARG_WITH(boost-headers,
-            [AC_HELP_STRING([--with-boost-headers=dir], [Boost headers directory])],
-            lmi_boost_headers=$withval)
-
 dnl add support for --wxdir, --wx-config, --wx-prefix, ----wx-exec-prefix
 WX_CONFIG_OPTIONS
 
@@ -359,55 +355,6 @@ dnl Restore pre-wx CPPFLAGS value only now, we needed wx flags for
 dnl wxPdfDocument checks.
 CPPFLAGS=$save_CPPFLAGS
 
-dnl Add clang-specific workaround before checking for Boost, as its headers use
-dnl std::allocator::size_type.
-dnl
-dnl This is necessary because libc++ used by clang 11 mistakenly removed
-dnl std::allocator::size_type, which is finally not removed by C++20. Luckily,
-dnl we still can predefine _LIBCPP_ENABLE_CXX20_REMOVED_ALLOCATOR_MEMBERS to
-dnl get its declaration, but we don't want to do this unconditionally because
-dnl this also reintroduces other, really removed, members in later clang
-dnl versions, so only do it if we need it.
-if test "$CLANG" = "yes"; then
-    m4_define([lmi_cxx_alloc_test], [[
-#include <memory>
-std::allocator<char*>::size_type s = 17;
-    ]])
-    AC_CACHE_CHECK([whether clang requires workaround for std::allocator::size_type],
-        lmi_cv_cxx_alloc_workaround_needed,
-        [
-            AC_LANG_PUSH([C++])
-            AC_COMPILE_IFELSE([AC_LANG_SOURCE([lmi_cxx_alloc_test])],
-                lmi_cv_cxx_alloc_workaround_needed=no,
-                [CXXFLAGS="$CXXFLAGS -D_LIBCPP_ENABLE_CXX20_REMOVED_ALLOCATOR_MEMBERS"
-                 AC_COMPILE_IFELSE([AC_LANG_SOURCE([lmi_cxx_alloc_test])],
-                    lmi_cv_cxx_alloc_workaround_needed=yes,
-                    AC_MSG_ERROR([std::allocator::size_type unavailable]))]
-            )
-            AC_LANG_POP([C++])
-        ]
-    )
-fi
-
-dnl --- Boost (required) ---
-if test "x$lmi_boost_headers" != "x"; then
-    CPPFLAGS="$CPPFLAGS -I$lmi_boost_headers"
-    errmsg="even in $lmi_boost_headers"
-else
-    errmsg="use --with-boost-headers=dir
-if they are installed in non default location"
-fi
-
-dnl Disable the use of std::auto_ptr<> and std::allocator::const_reference,
-dnl that don't exist in C++ 20 and that we don't need anyhow, in Boost code.
-CPPFLAGS="$CPPFLAGS -DBOOST_NO_AUTO_PTR -DBOOST_NO_STD_ALLOCATOR"
-
-AC_CHECK_HEADER([boost/type_traits.hpp],
-    [],
-    [AC_MSG_FAILURE([Boost headers not found, $errmsg])],
-    [AC_INCLUDES_DEFAULT()]
-)
-
 dnl check for the other required libraries: under Unix we use pkg-config which
 dnl is easily available for (and often already installed under) any Linux
 dnl system but when using Cygwin we do the checks manually as installing
@@ -599,16 +546,6 @@ if test "x$GXX" == "xyes"; then
         LMI_CXX_ADD_IF_SUPPORTED(-Wno-deprecated-anon-enum-enum-conversion)
         LMI_CXX_ADD_IF_SUPPORTED(-Wno-deprecated-volatile)
     fi
-
-    dnl Many instances of these warnings are given in Boost 1.33.1 headers, so
-    dnl we unfortunately have to disable them even if they're potentially
-    dnl useful, especially the latter one.
-    LMI_CXX_ADD_IF_SUPPORTED(-Wno-unused-local-typedefs)
-    LMI_CXX_ADD_IF_SUPPORTED(-Wno-unused-variable)
-
-    dnl This makes Boost compile with -Wundef; see workhorse.make for
-    dnl more detailed explanation.
-    CXXFLAGS="$CXXFLAGS -DBOOST_STRICT_CONFIG"
 fi
 
 dnl === Generate output files ===


### PR DESCRIPTION
They are not used by lmi any more.

Also remove various workarounds for compiling Boost in C++20 mode with
all warnings enabled.