### PR TITLE
Use ccache to speed up the CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           key: ${{ matrix.name }}
 
-      - name: System and environment setup
+      - name: Set up build environment
         run: |
           normal_uid=`id --user`
 
@@ -182,6 +182,8 @@ jobs:
           mkdir /opt/lmi/gui_test
           mkdir /opt/lmi/src
 
+      - name: Show build environment
+        run: |
           echo "User information:"
           id
           echo


### PR DESCRIPTION
This should be transparent for all build methods as ccache simply
replaces the compiler being used.