### PR TITLE
Allow using stifle_unused_warning() with uninitialized variables

### DIFF
--- a/miscellany.hpp
+++ b/miscellany.hpp
@@ -293,7 +293,7 @@ inline unsigned char lmi_toupper(unsigned char c)
 /// Avoid compiler warning for unused variable or unused value.
 
 template<typename T>
-constexpr void stifle_unused_warning(T const&)
+constexpr void stifle_unused_warning(T&)
 {}
 
 #endif // miscellany_hpp


### PR DESCRIPTION
Change stifle_unused_warning() to take non-const reference to avoid
-Wmaybe-uninitialized from gcc-11 when calling it with uninitialized
variables.