### PR TITLE
Run GUI test executable directly after gui_test.sh removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,10 +381,9 @@ jobs:
             make $coefficiency unit_tests
           fi
 
-      - name: Run GUI tests
+      - name: Launch Xvfb
         if: matrix.mingw
         run: |
-            echo 'Launching Xvfb...'
             sudo mkdir /tmp/.X11-unix
             sudo chmod 1777 /tmp/.X11-unix
             Xvfb :10 -screen 0 1600x1200x24 &
@@ -408,7 +407,10 @@ jobs:
                 echo "Still waiting for Xvfb (attempt #$num_tries)"
                 sleep 3
             done
-            echo 'Launching the GUI test:'
+            echo 'DISPLAY=:10' >> $GITHUB_ENV
+
+      - name: Run GUI tests
+        if: matrix.mingw
+        run: |
             . ./set_toolchain.sh
-            export DISPLAY=:10
             $PERFORM /opt/lmi/bin/wx_test --ash_nazg --data_path=/opt/lmi/data

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
           - name: MSW/make/mingw32
             triplet: i686-w64-mingw32
             mingw: true
+          - name: MSW/make/mingw64
+            triplet: x86_64-w64-mingw32
+            mingw: true
           - name: Linux/make/gcc
           - name: Linux/autotools/gcc
             autotools: true
@@ -75,14 +78,25 @@ jobs:
 
           if [ ${{ matrix.mingw }} ]
           then
-            packages="$packages g++-mingw-w64-i686 wine"
+            case "$LMI_TRIPLET" in
+              i686-*)
+                # This is additionally required when using 32-bit builds for
+                # installing 32 bit Wine which, in turn, is required for
+                # running 32 bit lmi binaries.
+                sudo dpkg --add-architecture i386
+                sudo apt-get -q -o=Dpkg::Use-Pty=0 update
 
-            # This is additionally required when using 32-bit builds, currently
-            # do it unconditionally because our only MinGW build is 32 bits.
-            sudo dpkg --add-architecture i386
-            sudo apt-get -q -o=Dpkg::Use-Pty=0 update
+                packages="$packages g++-mingw-w64-i686 wine wine32"
+                ;;
 
-            packages="$packages wine32"
+              x86_64-*)
+                packages="$packages g++-mingw-w64-x86-64 wine wine64"
+                ;;
+
+              *)
+                echo 'Unknown MinGW platform.'
+                exit 1
+            esac
           else
             packages="$packages libgtk-3-dev"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,4 +395,6 @@ jobs:
                 sleep 3
             done
             echo 'Launching the GUI test:'
-            DISPLAY=:10 ./gui_test.sh
+            . ./set_toolchain.sh
+            export DISPLAY=:10
+            $PERFORM /opt/lmi/bin/wx_test --ash_nazg --data_path=/opt/lmi/data


### PR DESCRIPTION
Stop using removed script in the CI workflow file.