### PR TITLE
Remove hard-coded wx{DatePicker,Spin}Ctrl sizes from XRC files

### DIFF
--- a/gpt.xrc
+++ b/gpt.xrc
@@ -279,7 +279,6 @@ TAXATION !! Flat extras are ignored ('7702.html' [8/6]), so remove this?
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="EffectiveDate">
                                         <help>Effective date</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -312,7 +311,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="DateOfBirth">
                                         <help>Date of birth</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -326,7 +324,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxSpinCtrl" name="IssueAge">
                                         <help>Insurance age on date of issue</help>
-                                        <size>80,-1</size>
                                         <style>wxSP_ARROW_KEYS</style>
                                     </object>
                                 </object>
@@ -416,7 +413,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="InforceAsOfDate">
                                         <help>Monthiversary as of which inforce data is provided</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -449,7 +445,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="LastMaterialChangeDate">
                                         <help>Beginning of most recent seven-pay period</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">

--- a/mec.xrc
+++ b/mec.xrc
@@ -311,7 +311,6 @@ TAXATION !! Flat extras are ignored ('7702.html' [8/6]), so remove this?
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="EffectiveDate">
                                         <help>Effective date</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -344,7 +343,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="DateOfBirth">
                                         <help>Date of birth</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -358,7 +356,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxSpinCtrl" name="IssueAge">
                                         <help>Insurance age on date of issue</help>
-                                        <size>80,-1</size>
                                         <style>wxSP_ARROW_KEYS</style>
                                     </object>
                                 </object>
@@ -418,7 +415,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="InforceAsOfDate">
                                         <help>Monthiversary as of which inforce data is provided</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -451,7 +447,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="LastMaterialChangeDate">
                                         <help>Beginning of most recent seven-pay period</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">

--- a/skin.xrc
+++ b/skin.xrc
@@ -180,7 +180,6 @@
                                             <flag>wxGROW|wxALIGN_CENTER_VERTICAL</flag>
                                             <object class="wxDatePickerCtrl" name="EffectiveDate">
                                                 <help>Effective date</help>
-                                                <size>90,-1</size>
                                             </object>
                                         </object>
                                     </object>
@@ -426,7 +425,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL</flag>
                                     <object class="wxDatePickerCtrl" name="LastCoiReentryDate">
                                         <help>Last COI reentry date</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                             </object>
@@ -446,7 +444,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL</flag>
                                     <object class="wxDatePickerCtrl" name="ListBillDate">
                                         <help>List bill date</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                             </object>
@@ -1096,7 +1093,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="DateOfBirth">
                                         <help>Date of birth</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -1109,7 +1105,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxSpinCtrl" name="IssueAge">
                                         <help>Insurance age on date of issue</help>
-                                        <size>80,-1</size>
                                         <style>wxSP_ARROW_KEYS</style>
                                     </object>
                                 </object>
@@ -1123,7 +1118,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxSpinCtrl" name="RetirementAge">
                                         <help>Insurance age on date of retirement</help>
-                                        <size>80,-1</size>
                                         <style>wxSP_ARROW_KEYS</style>
                                     </object>
                                 </object>
@@ -1293,7 +1287,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="InforceAsOfDate">
                                         <help>Monthiversary date as of which inforce data is provided</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -1709,7 +1702,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="LastMaterialChangeDate">
                                         <help>Beginning of most recent seven-pay period</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -2912,7 +2904,6 @@ the other is perforce ignored.
                                     <border>4</border>
                                     <object class="wxSpinCtrl" name="SpouseIssueAge">
                                         <help>Spouse's insurance age on date of issue</help>
-                                        <size>50,-1</size>
                                         <style>wxSP_ARROW_KEYS</style>
                                     </object>
                                 </object>

--- a/skin_coli_boli.xrc
+++ b/skin_coli_boli.xrc
@@ -180,7 +180,6 @@
                                             <border>2</border>
                                             <object class="wxDatePickerCtrl" name="EffectiveDate">
                                                 <help>Effective date</help>
-                                                <size>90,-1</size>
                                             </object>
                                         </object>
                                         <object class="sizeritem">
@@ -901,7 +900,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="DateOfBirth">
                                         <help>Date of birth</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -914,7 +912,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxSpinCtrl" name="IssueAge">
                                         <help>Insurance age on date of issue</help>
-                                        <size>80,-1</size>
                                         <style>wxSP_ARROW_KEYS</style>
                                     </object>
                                 </object>
@@ -928,7 +925,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxSpinCtrl" name="RetirementAge">
                                         <help>Insurance age on date of retirement</help>
-                                        <size>80,-1</size>
                                         <style>wxSP_ARROW_KEYS</style>
                                     </object>
                                 </object>
@@ -1329,7 +1325,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="InforceAsOfDate">
                                         <help>Monthiversary date as of which inforce data is provided</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -1773,7 +1768,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="LastMaterialChangeDate">
                                         <help>Beginning of most recent seven-pay period</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -1957,7 +1951,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                             <border>2</border>
                                             <object class="wxSpinCtrl" name="SolveBeginYear">
                                                 <help>Solve beginning duration</help>
-                                                <size>50,-1</size>
                                                 <style>wxSP_ARROW_KEYS</style>
                                             </object>
                                         </object>
@@ -1981,7 +1974,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                             <border>2</border>
                                             <object class="wxSpinCtrl" name="SolveBeginAge">
                                                 <help>Solve beginning age</help>
-                                                <size>50,-1</size>
                                                 <style>wxSP_ARROW_KEYS</style>
                                             </object>
                                         </object>
@@ -2038,7 +2030,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                             <border>2</border>
                                             <object class="wxSpinCtrl" name="SolveEndYear">
                                                 <help>Solve ending duration</help>
-                                                <size>50,-1</size>
                                                 <style>wxSP_ARROW_KEYS</style>
                                             </object>
                                         </object>
@@ -2062,7 +2053,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                             <border>2</border>
                                             <object class="wxSpinCtrl" name="SolveEndAge">
                                                 <help>Solve ending age</help>
-                                                <size>50,-1</size>
                                                 <style>wxSP_ARROW_KEYS</style>
                                             </object>
                                         </object>
@@ -2175,7 +2165,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                                     <border>2</border>
                                                     <object class="wxSpinCtrl" name="SolveTargetYear">
                                                         <help>Duration to achieve target surrender value</help>
-                                                        <size>50,-1</size>
                                                         <style>wxSP_ARROW_KEYS</style>
                                                     </object>
                                                 </object>
@@ -2199,7 +2188,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                                     <border>2</border>
                                                     <object class="wxSpinCtrl" name="SolveTargetAge">
                                                         <help>Attained age to achieve target surrender value</help>
-                                                        <size>50,-1</size>
                                                         <style>wxSP_ARROW_KEYS</style>
                                                     </object>
                                                 </object>
@@ -3143,7 +3131,6 @@ here, but it looks weird if we don't make this look like its siblings.
                             <border>2</border>
                             <object class="wxSpinCtrl" name="SpouseIssueAge">
                                 <help>Spouse insurance age on date of issue</help>
-                                <size>50,-1</size>
                                 <style>wxSP_ARROW_KEYS</style>
                             </object>
                         </object>

--- a/skin_group_carveout.xrc
+++ b/skin_group_carveout.xrc
@@ -202,7 +202,6 @@
                                     <border>2</border>
                                     <object class="wxDatePickerCtrl" name="EffectiveDate">
                                         <help>Effective date</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                             </object>
@@ -224,7 +223,6 @@
                                     <border>2</border>
                                     <object class="wxDatePickerCtrl" name="LastCoiReentryDate">
                                         <help>Last COI reentry date</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                             </object>
@@ -246,7 +244,6 @@
                                     <border>2</border>
                                     <object class="wxDatePickerCtrl" name="ListBillDate">
                                         <help>List bill date</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                             </object>
@@ -441,7 +438,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="DateOfBirth">
                                         <help>Date of birth</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -454,7 +450,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxSpinCtrl" name="IssueAge">
                                         <help>Insurance age on date of issue</help>
-                                        <size>80,-1</size>
                                         <style>wxSP_ARROW_KEYS</style>
                                     </object>
                                 </object>
@@ -468,7 +463,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxSpinCtrl" name="RetirementAge">
                                         <help>Insurance age on date of retirement</help>
-                                        <size>80,-1</size>
                                         <style>wxSP_ARROW_KEYS</style>
                                     </object>
                                 </object>
@@ -621,7 +615,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="InforceAsOfDate">
                                         <help>Monthiversary date as of which inforce data is provided</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -1065,7 +1058,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="LastMaterialChangeDate">
                                         <help>Beginning of most recent seven-pay period</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -1248,7 +1240,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                             <border>2</border>
                                             <object class="wxSpinCtrl" name="SolveBeginYear">
                                                 <help>Solve beginning duration</help>
-                                                <size>50,-1</size>
                                                 <style>wxSP_ARROW_KEYS</style>
                                             </object>
                                         </object>
@@ -1272,7 +1263,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                             <border>4</border>
                                             <object class="wxSpinCtrl" name="SolveBeginAge">
                                                 <help>Solve beginning age</help>
-                                                <size>50,-1</size>
                                                 <style>wxSP_ARROW_KEYS</style>
                                             </object>
                                         </object>
@@ -1328,7 +1318,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                             <border>2</border>
                                             <object class="wxSpinCtrl" name="SolveEndYear">
                                                 <help>Solve ending duration</help>
-                                                <size>50,-1</size>
                                                 <style>wxSP_ARROW_KEYS</style>
                                             </object>
                                         </object>
@@ -1352,7 +1341,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                             <border>4</border>
                                             <object class="wxSpinCtrl" name="SolveEndAge">
                                                 <help>Solve ending age</help>
-                                                <size>50,-1</size>
                                                 <style>wxSP_ARROW_KEYS</style>
                                             </object>
                                         </object>
@@ -1469,7 +1457,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                                             <border>2</border>
                                                             <object class="wxSpinCtrl" name="SolveTargetYear">
                                                                 <help>Duration to achieve target surrender value</help>
-                                                                <size>50,-1</size>
                                                                 <style>wxSP_ARROW_KEYS</style>
                                                             </object>
                                                         </object>
@@ -1493,7 +1480,6 @@ here, but it looks weird if we don't make this look like its siblings.
                                                             <border>2</border>
                                                             <object class="wxSpinCtrl" name="SolveTargetAge">
                                                                 <help>Attained age to achieve target surrender value</help>
-                                                                <size>50,-1</size>
                                                                 <style>wxSP_ARROW_KEYS</style>
                                                             </object>
                                                         </object>

--- a/skin_group_carveout3.xrc
+++ b/skin_group_carveout3.xrc
@@ -201,7 +201,6 @@
                                     <border>2</border>
                                     <object class="wxDatePickerCtrl" name="EffectiveDate">
                                         <help>Effective date</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                             </object>
@@ -223,7 +222,6 @@
                                     <border>2</border>
                                     <object class="wxDatePickerCtrl" name="LastCoiReentryDate">
                                         <help>Last COI reentry date</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                             </object>
@@ -418,7 +416,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="DateOfBirth">
                                         <help>Date of birth</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -431,7 +428,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxSpinCtrl" name="IssueAge">
                                         <help>Insurance age on date of issue</help>
-                                        <size>80,-1</size>
                                         <style>wxSP_ARROW_KEYS</style>
                                     </object>
                                 </object>
@@ -445,7 +441,6 @@
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxSpinCtrl" name="RetirementAge">
                                         <help>Insurance age on date of retirement</help>
-                                        <size>80,-1</size>
                                         <style>wxSP_ARROW_KEYS</style>
                                     </object>
                                 </object>
@@ -599,7 +594,6 @@
                                             <border>2</border>
                                             <object class="wxSpinCtrl" name="SolveBeginYear">
                                                 <help>Solve beginning duration</help>
-                                                <size>50,-1</size>
                                                 <style>wxSP_ARROW_KEYS</style>
                                             </object>
                                         </object>
@@ -623,7 +617,6 @@
                                             <border>4</border>
                                             <object class="wxSpinCtrl" name="SolveBeginAge">
                                                 <help>Solve beginning age</help>
-                                                <size>50,-1</size>
                                                 <style>wxSP_ARROW_KEYS</style>
                                             </object>
                                         </object>
@@ -679,7 +672,6 @@
                                             <border>2</border>
                                             <object class="wxSpinCtrl" name="SolveEndYear">
                                                 <help>Solve ending duration</help>
-                                                <size>50,-1</size>
                                                 <style>wxSP_ARROW_KEYS</style>
                                             </object>
                                         </object>
@@ -703,7 +695,6 @@
                                             <border>4</border>
                                             <object class="wxSpinCtrl" name="SolveEndAge">
                                                 <help>Solve ending age</help>
-                                                <size>50,-1</size>
                                                 <style>wxSP_ARROW_KEYS</style>
                                             </object>
                                         </object>
@@ -820,7 +811,6 @@
                                                             <border>2</border>
                                                             <object class="wxSpinCtrl" name="SolveTargetYear">
                                                                 <help>Duration to achieve target surrender value</help>
-                                                                <size>50,-1</size>
                                                                 <style>wxSP_ARROW_KEYS</style>
                                                             </object>
                                                         </object>
@@ -844,7 +834,6 @@
                                                             <border>2</border>
                                                             <object class="wxSpinCtrl" name="SolveTargetAge">
                                                                 <help>Attained age to achieve target surrender value</help>
-                                                                <size>50,-1</size>
                                                                 <style>wxSP_ARROW_KEYS</style>
                                                             </object>
                                                         </object>

--- a/skin_single_premium.xrc
+++ b/skin_single_premium.xrc
@@ -83,7 +83,6 @@
                             <border>4</border>
                             <object class="wxDatePickerCtrl" name="EffectiveDate">
                                 <help>Effective date</help>
-                                <size>90,-1</size>
                             </object>
                         </object>
                     </object>
@@ -787,7 +786,6 @@ appropriate input.
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxDatePickerCtrl" name="DateOfBirth">
                                         <help>Date of birth</help>
-                                        <size>90,-1</size>
                                     </object>
                                 </object>
                                 <object class="sizeritem">
@@ -800,7 +798,6 @@ appropriate input.
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxSpinCtrl" name="IssueAge">
                                         <help>Insurance age on date of issue</help>
-                                        <size>80,-1</size>
                                         <style>wxSP_ARROW_KEYS</style>
                                     </object>
                                 </object>
@@ -814,7 +811,6 @@ appropriate input.
                                     <flag>wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
                                     <object class="wxSpinCtrl" name="RetirementAge">
                                         <help>Insurance age on date of retirement</help>
-                                        <size>80,-1</size>
                                         <style>wxSP_ARROW_KEYS</style>
                                     </object>
                                 </object>


### PR DESCRIPTION
The sizes specified for wxSpinCtrl were too small and resulted in
truncating the control "-/+" buttons in the GTK-based version, as well
as tons of GTK debugging messages.

The size specified for wxDatePickerCtrl didn't result in any apparent
problems, but it could, potentially, depending on the theme and the date
format in the current locale, so don't hard-code the sizes for them
neither, as this is at best useless.

This generalizes the changes done in caee09caa (Remove invalid spinctrl
sizes, 2020-07-24) to all spin controls and wxDatePickerCtrl too.