### PR TITLE
Use fixed version of TIFF submodule in the CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,12 @@ jobs:
             echo
           fi
 
+      - name: Fix up TIFF submodule
+        run: |
+          cd third_party/wx/src/tiff
+          git fetch origin
+          git switch --detach af035310bddac3e2f58ae0a330bc6ef168e180f1
+
       - name: Cache downloaded archives
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
This will become unnecessary once the entire wxWidgets submodule is
updated to include the fixed version TIFF submodule and even more
unnecessary when support for 32-bit builds is dropped entirely, but for
now this should allow the 32-bit CI builds to run successfully instead
of triggering an error after every push.