### PR TITLE
Define endianness macros for MSVC

### DIFF
--- a/fdlibm.hpp
+++ b/fdlibm.hpp
@@ -51,6 +51,14 @@
 #   endif // !defined __FLOAT_WORD_ORDER__ && defined __BYTE_ORDER__
 #endif // defined __clang__
 
+// And MSVC maintainers don't believe in having different endianness
+// values at all, so the compiler never predefines these symbols.
+#if defined LMI_MSC
+    #define __ORDER_BIG_ENDIAN__ 4321
+    #define __ORDER_LITTLE_ENDIAN__ 1234
+    #define __FLOAT_WORD_ORDER__ __ORDER_LITTLE_ENDIAN__
+#endif // defined LMI_MSC
+
 #if !defined __FLOAT_WORD_ORDER__ || \
     !defined __ORDER_BIG_ENDIAN__ || \
     !defined __ORDER_LITTLE_ENDIAN__

--- a/fdlibm.hpp
+++ b/fdlibm.hpp
@@ -45,11 +45,11 @@
 
 // Apparently the clang maintainers believe that floating-point
 // endianness is necessarily the same as integer endianness.
-#if defined __clang__
+#if defined LMI_CLANG
 #   if !defined __FLOAT_WORD_ORDER__ && defined __BYTE_ORDER__
 #       define __FLOAT_WORD_ORDER__ __BYTE_ORDER__
 #   endif // !defined __FLOAT_WORD_ORDER__ && defined __BYTE_ORDER__
-#endif // defined __clang__
+#endif // defined LMI_CLANG
 
 // And MSVC maintainers don't believe in having different endianness
 // values at all, so the compiler never predefines these symbols.


### PR DESCRIPTION
This is required to build the current master with MSVC.