### PR TITLE
Update CI workflow to use LLVM libunwind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,11 @@ jobs:
           if [ -z "${{ matrix.autotools }}" -o -z "${{ matrix.mingw }}" ]; then
             # Those are never used with clang currently.
             if [ "${{ matrix.compiler }}" != clang ]; then
-              packages="$packages libunwind-dev libdw-dev"
+              # Instead of installing libunwind-NN-dev directly, install
+              # libc++-dev depending on it, as the latter depends on the
+              # former but has a version-independent name which doesn't need
+              # to be updated with each clang release.
+              packages="$packages libc++-dev libdw-dev"
             fi
             packages="$packages libpcre2-dev"
           fi

--- a/configure.ac
+++ b/configure.ac
@@ -416,9 +416,37 @@ fi
 
 dnl --- libunwind and libdw, only used under Linux and only with gcc/libstdc++
 if test "$USE_LINUX" = "1" -a "$CLANG" != "yes"; then
-    PKG_CHECK_MODULES(UNWIND, libunwind libdw)
-    CXXFLAGS="$CXXFLAGS $UNWIND_CFLAGS"
-    LIBS="$LIBS $UNWIND_LIBS -ldl"
+    PKG_CHECK_MODULES(LIBDW, libdw)
+    CXXFLAGS="$CXXFLAGS $LIBDW_CFLAGS"
+    LIBS="$LIBS $LIBDW_LIBS -ldl"
+
+    dnl Unfortunately LLVM libunwind doesn't have pkg-config support and so we
+    dnl have to test for it manually. Moreover, it installs its header in an
+    dnl apparently inconsistent way and we need to add a non-standard include
+    dnl directory to the search path to find them.
+    CXXFLAGS="$CXXFLAGS -I/usr/include/libunwind"
+    LIBS="$LIBS -lunwind"
+
+    AC_CACHE_CHECK([for libunwind],
+        lmi_cv_libunwind,
+        [
+            AC_LINK_IFELSE([AC_LANG_SOURCE([
+#include <libunwind.h>
+
+int main() {
+    unw_context_t context;
+    unw_getcontext(&context);
+}
+                ])],
+                lmi_cv_libunwind=yes,
+                lmi_cv_libunwind=no
+            )
+        ]
+    )
+
+    if test "x$lmi_cv_libunwind" != "xyes"; then
+        AC_MSG_FAILURE([Unable to build test program using libunwind, please check its installation.])
+    fi
 fi
 
 dnl --- CGICC (optional) ----------------


### PR DESCRIPTION
It is now required by lmi instead of the old and slightly incompatible version of the library.