### PR TITLE
Don't use wxClientDC class unnecessarily

### DIFF
--- a/rounding_view_editor.cpp
+++ b/rounding_view_editor.cpp
@@ -29,7 +29,6 @@
 
 #include <wx/bitmap.h>
 #include <wx/bmpbuttn.h>
-#include <wx/dcclient.h>                // class wxClientDC
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
 #include <wx/tglbtn.h>
@@ -228,12 +227,9 @@ wxSize RoundingButtons::CalculateMinimumTextControlSize
     ,unsigned int n
     )
 {
-    wxClientDC dc(window);
-    dc.SetFont(window->GetFont());
-
     wxCoord w, h;
     // Assume that 'W' is the widest letter.
-    dc.GetTextExtent("W", &w, &h);
+    window->GetTextExtent("W", &w, &h);
 
     wxSize size(w * n, h);
     size += window->GetSize() - window->GetClientSize();


### PR DESCRIPTION
It is not really needed here as wxWindow itself provides the same GetTextExtent() function too and not using it makes the code shorter and simpler.

No real changes.