### PR TITLE
Use wxWidgets support for safely showing message boxes

### DIFF
--- a/alert_wx.cpp
+++ b/alert_wx.cpp
@@ -138,35 +138,12 @@ void alarum_alert(std::string const& s)
 
 /// Show a message reliably, even before initialization has finished
 /// or after termination has begun.
-///
-/// The msw implementation of wxSafeShowMessage() uses ::MessageBoxA()
-/// with a null parent, which adds an undesirable extra "task" to the
-/// alt-Tab order, yet doesn't disable the application's top window.
-///
-/// If MB_TASKMODAL is specified, then the extra "task" is still
-/// added, but all of the application's top windows are disabled.
-/// Unfortunately, MB_TASKMODAL is in effect ignored unless the parent
-/// is null.
-///
-/// If the main top window (the one returned by wxApp::GetTopWindow())
-/// is used as the messagebox's parent, then the extra "task" is not
-/// added, but only the parent is disabled. Any other top windows the
-/// application may have are not disabled.
-///
-/// The extra "task" seeming to be the worse evil, this implementation
-/// specifies a non-null parent wherever possible. MB_TASKMODAL is
-/// nevertheless specified as well, though its beneficial effect is
-/// realized only if no parent can be found.
 
 void safe_message_alert(char const* message)
 {
+    // We don't use wxSafeShowMessage() here for the same reasons as in
+    // warning_alert() above.
     safely_show_on_stderr(message);
-#if defined LMI_MSW
-    auto handle =
-        (wxTheApp && wxTheApp->GetTopWindow())
-        ? wxTheApp->GetTopWindow()->GetHandle()
-        : nullptr
-        ;
-    ::MessageBoxA(handle, message, "Error", MB_OK | MB_ICONSTOP | MB_TASKMODAL);
-#endif // defined LMI_MSW
+
+    wxApp::GetValidTraits().SafeMessageBox(message, "Error");
 }

--- a/alert_wx.cpp
+++ b/alert_wx.cpp
@@ -27,6 +27,7 @@
 #include "force_linking.hpp"
 
 #include <wx/app.h>                     // wxTheApp
+#include <wx/apptrait.h>
 #include <wx/frame.h>
 #include <wx/msgdlg.h>
 #if defined LMI_MSW
@@ -73,7 +74,14 @@ void status_alert(std::string const& s)
 void warning_alert(std::string const& s)
 {
     std::cerr << "Warning: " << s << std::endl;
-    wxMessageBox(s, "Warning", wxOK, wxTheApp ? wxTheApp->GetTopWindow() : nullptr);
+
+    // We don't use wxSafeShowMessage() here because it would only log the
+    // message to stderr if the message box cannot be shown, while we want to
+    // always log it, even in addition to showing the message box.
+    //
+    // So we use a lower-level function used by wxSafeShowMessage() and simply
+    // ignore its return value, indicating whether it could show the box or not.
+    wxApp::GetValidTraits().SafeMessageBox(s, "Warning");
 }
 
 /// It seems silly to offer an option that should never be declined,

--- a/main_wx_test.cpp
+++ b/main_wx_test.cpp
@@ -388,7 +388,7 @@ bool application_test::process_command_line(int& argc, char* argv[])
                    "Additionally, all command line options supported by the\n"
                    "main lmi executable are also supported."
                 ;
-            wxMessageBox(oss.str(), "Command-line options");
+            wxSafeShowMessage("Command-line options", oss.str());
             return false;
             }
         else


### PR DESCRIPTION
Use `wxSafeShowMessage()` itself if possible or the lower-level function used for its implementation otherwise.

This fixes errors when using using `wx_test -h` or `warning_alert()` during the app initialization under non-MSW platforms and simplifies, without changing it for MSW, `safe_message_alert()` -- and also improves it for the other platforms by showing a message box from it, if possible.